### PR TITLE
Add .sectionHeading module

### DIFF
--- a/style/index.css
+++ b/style/index.css
@@ -1,3 +1,5 @@
 @import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Sans&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Libre+Franklin:wght@700&display=swap');
 @import url('base.css');
 @import url('layout.css');
+@import url('modules/sectionHeading.css');

--- a/style/modules/sectionHeading.css
+++ b/style/modules/sectionHeading.css
@@ -1,0 +1,6 @@
+.sectionHeading {
+    font-family: "libre franklin";
+    font-weight: 700;
+    color: #113255;
+    font-size: 48px;
+}


### PR DESCRIPTION
This PR adds a module called `.sectionHeading` which we can use for the major page section headings (typically h1). It's blue / bold / franklin.

<img width="478" alt="Screen Shot 2020-08-25 at 6 37 00 PM" src="https://user-images.githubusercontent.com/733916/91245525-7f4e2500-e702-11ea-9b79-5796722de803.png">
