### PR TITLE
Add inner div to page previews in storybook

### DIFF
--- a/storybook/script.js
+++ b/storybook/script.js
@@ -9,8 +9,11 @@ const titlebar = () =>
     .addClass('sbPage--titlebar')
     .append(['red', 'yellow', 'green'].map(c => button(c)))
 
-const page = contents =>
-  $('<div>').addClass('sbPage').append(titlebar(), contents)
+const page = contents => {
+  const inner = $('<div>').addClass('sbPage--inner').append(contents)
+  const div = $('<div>').addClass('sbPage').append(titlebar(), inner)
+  return div
+}
 
 
 for (const section of $('.demo')) {

--- a/storybook/style.css
+++ b/storybook/style.css
@@ -2,7 +2,6 @@
 
 body {
   font-family: 'ibm plex sans';
-  min-width: 600;
 }
 
 section {

--- a/storybook/style.css
+++ b/storybook/style.css
@@ -29,6 +29,10 @@ section .sbHeading {
   overflow-x: hidden;
 }
 
+.sbPage--inner {
+  padding: 16px;
+}
+
 .sbPage--titlebar {
   background-color: #ddd;
   height: 24px;


### PR DESCRIPTION
This fixes a problem in storybook where items outside the "box model" (e.g. box shadows) for a module are clipped by the page previews, by adding an inner div (`.sbPage--inner`).

example of it working:
<img width="728" alt="Screen Shot 2020-08-28 at 5 00 16 PM" src="https://user-images.githubusercontent.com/733916/91623366-122fcf00-e950-11ea-8752-5e04508172c1.png">
