### PR TITLE
Prevent .gridBox children from growing

### DIFF
--- a/style/modules/gridBox.css
+++ b/style/modules/gridBox.css
@@ -11,13 +11,13 @@
 /* columns */
 
 .gridBox-col1 > * {
-    flex: 1 0 100%;
+    flex-basis: 100%;
 }
 
 .gridBox-col2 > * {
-    flex: 1 0 45%;
+    flex-basis: 45%;
 }
 
 .gridBox-col3 > * {
-    flex: 1 0 30%;
+    flex-basis: 30%;
 }

--- a/style/modules/gridBox.css
+++ b/style/modules/gridBox.css
@@ -1,11 +1,9 @@
 .gridBox { /* a container with grid */
     display: flex;
     flex-wrap: wrap;
-    font-size: 0 /* this was done to fight the space between blocks */
 }
 
 .gridBox > * {  /* applies to all the items in the grid */
-    display: inline-block;
     vertical-align: top;
     margin: 5px; /* the space between blocks. Doesn't affect on the components inside the blocks */
 }


### PR DESCRIPTION
This PR changes two small things about `.gridBox`:

1. Removes `display:inline-block` property from children, which I don't think will add any behavior beyond what `flex-wrap` already does. Having it makes `font-size: 0` necessary, but we'll want to avoid `font-size: 0` since having it means the children will need to override it later.

2. Removes `flex-grow` from the children (and also `flex-shrink`, which is less important here) by swapping the `flex` shorthand for the `flex-basis` property.

Before (note, this example uses `gridBox-col2`):
<img width="777" alt="Screen Shot 2020-09-02 at 9 11 30 PM" src="https://user-images.githubusercontent.com/733916/92072101-4bf44180-ed65-11ea-8eaf-4b67f11cead8.png">

After (note, this example uses `gridBox-col3`):
<img width="838" alt="Screen Shot 2020-09-02 at 9 39 32 PM" src="https://user-images.githubusercontent.com/733916/92072119-59a9c700-ed65-11ea-9fc9-82f419ee2c16.png">
