### PR TITLE
Un-nest .missionStatement

### DIFF
--- a/storybook/index.html
+++ b/storybook/index.html
@@ -43,7 +43,7 @@
                     <input id="q2" type="checkbox" class="faq--checkbox">
                         <label for="q2" class="faq--question">
                             What is the meaning of life?
-    
+
                             <div class="faq--plus">+</div>
                         </label>
                     <div class="faq--answers">42</div>
@@ -52,7 +52,7 @@
                     <input id="q3" type="checkbox" class="faq--checkbox">
                         <label for="q3" class="faq--question">
                             What is the meaning of life?
-        
+
                             <div class="faq--plus">+</div>
                         </label>
                     <div class="faq--answers">42</div>
@@ -138,13 +138,11 @@
         </section>
 
         <section class="demo">
-            <div class="missionStatment">
-                <div class="missionStatement--box">
-                    <div class="missionStatement--logo">
-                        <img src="../images/logo-gold-border.svg">
-                    </div>
-                    <p>Our program is constantly establishing new standards of excellence in the practice of public and contemporary art creation and exhibition. Our collaborative dialogue processes empower artists and communities to address and organize issues in the community. Community art builds bridges from conceptual connection to a physical understanding. With close attention to our clients desires the results are beautiful murals that inspire and motivate viewers.</p>
+            <div class="missionStatement">
+                <div class="missionStatement--logo">
+                    <img src="../images/logo-gold-border.svg">
                 </div>
+                <p>Our program is constantly establishing new standards of excellence in the practice of public and contemporary art creation and exhibition. Our collaborative dialogue processes empower artists and communities to address and organize issues in the community. Community art builds bridges from conceptual connection to a physical understanding. With close attention to our clients desires the results are beautiful murals that inspire and motivate viewers.</p>
             </div>
         </section>
     </body>

--- a/style/modules/missionStatement.css
+++ b/style/modules/missionStatement.css
@@ -1,4 +1,4 @@
-.missionStatement--box {
+.missionStatement {
     max-width: 60%;
     margin: 0 auto;
     margin-top: 110px;
@@ -22,7 +22,7 @@
     margin-left: -120px;
 }
 
-.missionStatement--box > p {
+.missionStatement > p {
     margin-top: 90px;
     font-size: 30px;
     font-style: italic;
@@ -31,7 +31,7 @@
 }
 
 @media only screen and (max-width: 600px) {
-    .missionStatement--box {
+    .missionStatement {
         margin-top: 60px;
         max-width: 80%;
         padding-left: 30px;
@@ -40,7 +40,7 @@
         text-align: center;
      }
 
-    .missionStatement--box > p {
+    .missionStatement > p {
        font-size: 16px;
        margin-top: 60px;
     }


### PR DESCRIPTION
This PR removes a level of nesting by renaming `.missionStatement--box` to `.missionStatement` (which was unstyled). Shouldn't change behavior.