### PR TITLE
Add left nav to storybook

### DIFF
--- a/storybook/index.html
+++ b/storybook/index.html
@@ -108,6 +108,16 @@
                     <h1 class="sectionHeading">Hello</h1>
                     <h1 class="sectionHeading">Hello</h1>
                 </div>
+                <p class="sbVariant">.gridBox.gridBox-col4.gridBox-center</p>
+                <div class="gridBox gridBox-col4 gridBox-center">
+                    <h1 class="sectionHeading">Hello</h1>
+                    <h1 class="sectionHeading">Hello</h1>
+                    <h1 class="sectionHeading">Hello</h1>
+                    <h1 class="sectionHeading">Hello</h1>
+                    <h1 class="sectionHeading">Hello</h1>
+                    <h1 class="sectionHeading">Hello</h1>
+                    <h1 class="sectionHeading">Hello</h1>
+                </div>
             </section>
 
             <section class="demo" data-module-name="missionStatement">

--- a/storybook/index.html
+++ b/storybook/index.html
@@ -10,184 +10,187 @@
         <script src="script.js" defer></script>
     </head>
 
-    <body>
-        <section class="demo">
-            <div class="box">
-                Hello
-            </div>
-            <div class="box box-red">
-                Hello
-            </div>
-            <div class="box box-blue">
-                Hello
-            </div>
-            <div class="box box-yellow">
-                Hello
-            </div>
-        </section>
+    <body class="l-body">
+        <nav class="l-sidebar">
+            <h2 class="sbNavHeading">Modules</h2>
+            <ul class="sbNavList"><!-- list items will be added dynamically --></ul>
+        </nav>
 
-        <section class="demo">
-            <div class="faqContainer">
-                <div class="faq">
-                    <input id="q1" type="checkbox" class="faq--checkbox">
-                        <label for="q1" class="faq--question">
-                            What is the meaning of life?
+        <main class="l-main">
+            <section class="demo" data-module-name="box">
+                <div class="box">
+                    Hello
+                </div>
+                <div class="box box-red">
+                    Hello
+                </div>
+                <div class="box box-blue">
+                    Hello
+                </div>
+                <div class="box box-yellow">
+                    Hello
+                </div>
+            </section>
 
-                            <div class="faq--plus">+</div>
-                        </label>
-                    <div class="faq--answers">
-                        Life is very complex, so just live the best life. Nothing really matters, just go go with the flow. We're all figuring it out as we go. Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.
+            <section class="demo" data-module-name="faq">
+                <div class="faqContainer">
+                    <div class="faq">
+                        <input id="q1" type="checkbox" class="faq--checkbox">
+                            <label for="q1" class="faq--question">
+                                What is the meaning of life?
+                                <div class="faq--plus">+</div>
+                            </label>
+                        <div class="faq--answers">
+                            Life is very complex, so just live the best life. Nothing really matters, just go go with the flow. We're all figuring it out as we go. Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.
+                        </div>
+                    </div>
+                    <div class="faq">
+                        <input id="q2" type="checkbox" class="faq--checkbox">
+                            <label for="q2" class="faq--question">
+                                What is the meaning of life?
+                                <div class="faq--plus">+</div>
+                            </label>
+                        <div class="faq--answers">42</div>
+                    </div>
+                    <div class="faq">
+                        <input id="q3" type="checkbox" class="faq--checkbox">
+                            <label for="q3" class="faq--question">
+                                What is the meaning of life?
+                                <div class="faq--plus">+</div>
+                            </label>
+                        <div class="faq--answers">42</div>
                     </div>
                 </div>
-                <div class="faq">
-                    <input id="q2" type="checkbox" class="faq--checkbox">
-                        <label for="q2" class="faq--question">
-                            What is the meaning of life?
+            </section>
 
-                            <div class="faq--plus">+</div>
-                        </label>
-                    <div class="faq--answers">42</div>
+            <section class="demo" data-module-name="gridBox">
+                <div class="gridBox gridBox-col1">
+                    <div>
+                        <h1 class="sectionHeading">Hello</h1>
+                    </div>
                 </div>
-                <div class="faq">
-                    <input id="q3" type="checkbox" class="faq--checkbox">
-                        <label for="q3" class="faq--question">
-                            What is the meaning of life?
+                <div class="gridBox gridBox-col2">
+                    <div>
+                        <h1 class="sectionHeading">Hello</h1>
+                    </div>
+                    <div>
+                        <h1 class="sectionHeading">Hello</h1>
+                    </div>
+                    <div>
+                        <h1 class="sectionHeading">Hello</h1>
+                    </div>
+                </div>
+                <div class="gridBox gridBox-col3">
+                    <div>
+                        <h1 class="sectionHeading">Hello</h1>
+                    </div>
+                    <div>
+                        <h1 class="sectionHeading">Hello</h1>
+                    </div>
+                    <div>
+                        <h1 class="sectionHeading">Hello</h1>
+                    </div>
+                    <div>
+                        <h1 class="sectionHeading">Hello</h1>
+                    </div>
+                    <div>
+                        <h1 class="sectionHeading">Hello</h1>
+                    </div>
+                    <div>
+                        <h1 class="sectionHeading">Hello</h1>
+                    </div>
+                </div>
+            </section>
 
-                            <div class="faq--plus">+</div>
-                        </label>
-                    <div class="faq--answers">42</div>
+            <section class="demo" data-module-name="scrollCarousel">
+                <div class="scrollCarousel">
+                    <div class="scrollCarousel--contents">
+                        <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
+                        <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
+                        <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
+                        <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
+                        <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
+                        <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
+                        <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
+                        <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
+                        <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
+                        <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
+                        <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
+                        <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
+                        <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
+                        <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
+                        <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
+                        <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
+                        <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
+                        <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
+                        <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
+                        <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
+                        <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
+                        <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
+                        <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
+                        <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
+                        <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
+                        <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
+                        <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
+                        <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
+                        <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
+                        <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
+                    </div>
                 </div>
-            </div>
-        </section>
+            </section>
 
-        <section class="demo">
-            <div class="gridBox gridBox-col1">
-                <div>
-                    <h1 class="sectionHeading">Hello</h1>
+            <section class="demo" data-module-name="teamMember">
+                <div class="teamMember">
+                    <div class="teamMember--photo">
+                        <img src="https://fm.cnbc.com/applications/cnbc.com/resources/img/editorial/2020/09/09/106695701-1599664926959-gettyimages-1228423382-AFP_8PL8JF.600x400.jpeg?v=1599664969">
+                    </div>
+                    <div class="teamMember--name">
+                        Andre Jones
+                    </div>
+                    <div class="teamMember--role">
+                        BAMP Executive Director/ <br> Lead Artist
+                    </div>
+                    <a class="teamMember--icon" href="#">
+                        <img src="../images/linkedin.svg">
+                    </a>
+                    <a class="teamMember--icon" href="#">
+                        <img src="../images/mail.svg">
+                    </a>
                 </div>
-            </div>
+            </section>
 
-            <div class="gridBox gridBox-col2">
-                <div>
-                    <h1 class="sectionHeading">Hello</h1>
+            <section class="demo" data-module-name="missionStatement">
+                <div class="missionStatement">
+                    <div class="missionStatement--logo">
+                        <img src="../images/logo-gold-border.svg">
+                    </div>
+                    <p>Our program is constantly establishing new standards of excellence in the practice of public and contemporary art creation and exhibition. Our collaborative dialogue processes empower artists and communities to address and organize issues in the community. Community art builds bridges from conceptual connection to a physical understanding. With close attention to our clients desires the results are beautiful murals that inspire and motivate viewers.</p>
                 </div>
-                <div>
-                    <h1 class="sectionHeading">Hello</h1>
-                </div>
-                <div>
-                    <h1 class="sectionHeading">Hello</h1>
-                </div>
-            </div>
-            <div class="gridBox gridBox-col3">
-                <div>
-                    <h1 class="sectionHeading">Hello</h1>
-                </div>
-                <div>
-                    <h1 class="sectionHeading">Hello</h1>
-                </div>
-                <div>
-                    <h1 class="sectionHeading">Hello</h1>
-                </div>
-                <div>
-                    <h1 class="sectionHeading">Hello</h1>
-                </div>
-                <div>
-                    <h1 class="sectionHeading">Hello</h1>
-                </div>
-                <div>
-                    <h1 class="sectionHeading">Hello</h1>
-                </div>
-            </div>
-        </section>
+            </section>
 
-        <section class="demo">
-            <div class="scrollCarousel">
-                <div class="scrollCarousel--contents">
-                    <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
-                    <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
-                    <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
-                    <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
-                    <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
-                    <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
-                    <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
-                    <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
-                    <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
-                    <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
-                    <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
-                    <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
-                    <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
-                    <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
-                    <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
-                    <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
-                    <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
-                    <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
-                    <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
-                    <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
-                    <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
-                    <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
-                    <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
-                    <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
-                    <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
-                    <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
-                    <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
-                    <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
-                    <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
-                    <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
+            <section class="demo" data-module-name="testimonial">
+                <div class="testimonial">
+                    <div class="testimonial--pic">
+                        <img src="https://cdn.pixabay.com/photo/2015/04/23/22/00/tree-736885__340.jpg">
+                    </div>
+                    <div class="testimonial--content">
+                        <span class="testimonial--name">Community Member</span>
+                        <p class="testimonial--quote">“Whether I shall turn out to be the hero of my own life, or whether that station will be held by anybody else, these pages must show.”</p>
+                    </div>
                 </div>
-            </div>
-        </section>
+            </section>
 
-        <section class="demo">
-            <div class="teamMember">
-                <div class="teamMember--photo">
-                    <img src="https://fm.cnbc.com/applications/cnbc.com/resources/img/editorial/2020/09/09/106695701-1599664926959-gettyimages-1228423382-AFP_8PL8JF.600x400.jpeg?v=1599664969">
-                </div>
-                <div class="teamMember--name">
-                    Andre Jones
-                </div>
-                <div class="teamMember--role">
-                    BAMP Executive Director/ <br> Lead Artist
-                </div>
-                <a class="teamMember--icon" href="#">
-                    <img src="../images/linkedin.svg">
-                </a>
-                <a class="teamMember--icon" href="#">
-                    <img src="../images/mail.svg">
-                </a>
-            </div>
-        </section>
-
-        <section class="demo">
-            <div class="missionStatement">
-                <div class="missionStatement--logo">
-                    <img src="../images/logo-gold-border.svg">
-                </div>
-                <p>Our program is constantly establishing new standards of excellence in the practice of public and contemporary art creation and exhibition. Our collaborative dialogue processes empower artists and communities to address and organize issues in the community. Community art builds bridges from conceptual connection to a physical understanding. With close attention to our clients desires the results are beautiful murals that inspire and motivate viewers.</p>
-            </div>
-        </section>
-
-        <section class="demo">
-            <div class="testimonial">
-                <div class="testimonial--pic">
-                    <img src="https://cdn.pixabay.com/photo/2015/04/23/22/00/tree-736885__340.jpg">
-                </div>
-                <div class="testimonial--content">
-                    <span class="testimonial--name">Community Member</span>
-                    <p class="testimonial--quote">“Whether I shall turn out to be the hero of my own life, or whether that station will be held by anybody else, these pages must show.”</p>
-                </div>
-            </div>
-        </section>
-
-        <section class="demo">
-            <p>Small</p>
-            <a class="btnLink btnLink-small" href="https://www.youtube.com/watch?v=dQw4w9WgXcQ">Button</a>
-            <a class="btnLink btnLink-red btnLink-small">Button</a>
-            <p>Normal</p>
-            <a class="btnLink">Button</a>
-            <a class="btnLink btnLink-red">Button</a>
-            <p>Large</p>
-            <a class="btnLink btnLink-large">Button</a>
-            <a class="btnLink btnLink-red btnLink-large">Button</a>
-        </section>
+            <section class="demo" data-module-name="btnLink">
+                <p>Small</p>
+                <a class="btnLink btnLink-small" href="https://www.youtube.com/watch?v=dQw4w9WgXcQ">Button</a>
+                <a class="btnLink btnLink-red btnLink-small">Button</a>
+                <p>Normal</p>
+                <a class="btnLink">Button</a>
+                <a class="btnLink btnLink-red">Button</a>
+                <p>Large</p>
+                <a class="btnLink btnLink-large">Button</a>
+                <a class="btnLink btnLink-red btnLink-large">Button</a>
+            </section>
+        </main>
     </body>
 </html>

--- a/storybook/index.html
+++ b/storybook/index.html
@@ -176,7 +176,7 @@
                         Andre Jones
                     </div>
                     <div class="teamMember--role">
-                        BAMP Executive Director/ <br> Lead Artist
+                        BAMP Executive Director / <br> Lead Artist
                     </div>
                     <a class="teamMember--icon" href="#">
                         <img src="../images/linkedin.svg">

--- a/storybook/index.html
+++ b/storybook/index.html
@@ -12,7 +12,7 @@
 
     <body class="l-body">
         <nav class="l-sidebar">
-            <h2 class="sbNavHeading">Modules</h2>
+            <h2 class="sbHeading">Modules</h2>
             <ul class="sbNavList"><!-- list items will be added dynamically --></ul>
         </nav>
 

--- a/storybook/index.html
+++ b/storybook/index.html
@@ -188,15 +188,17 @@
             </section>
 
             <section class="demo" data-module-name="testimonial">
-                <div class="testimonial">
-                    <div class="testimonial--pic">
-                        <img src="https://cdn.pixabay.com/photo/2015/04/23/22/00/tree-736885__340.jpg">
+                <center>
+                    <div class="testimonial">
+                        <div class="testimonial--pic">
+                            <img src="https://cdn.pixabay.com/photo/2015/04/23/22/00/tree-736885__340.jpg">
+                        </div>
+                        <div class="testimonial--content">
+                            <span class="testimonial--name">Community Member</span>
+                            <p class="testimonial--quote">“Whether I shall turn out to be the hero of my own life, or whether that station will be held by anybody else, these pages must show.”</p>
+                        </div>
                     </div>
-                    <div class="testimonial--content">
-                        <span class="testimonial--name">Community Member</span>
-                        <p class="testimonial--quote">“Whether I shall turn out to be the hero of my own life, or whether that station will be held by anybody else, these pages must show.”</p>
-                    </div>
-                </div>
+                </center>
             </section>
         </main>
     </body>

--- a/storybook/index.html
+++ b/storybook/index.html
@@ -98,6 +98,7 @@
                     <h1 class="sectionHeading">Hello</h1>
                     <h1 class="sectionHeading">Hello</h1>
                 </div>
+                <p class="sbVariant">.gridBox.gridBox-col4</p>
                 <div class="gridBox gridBox-col4">
                     <h1 class="sectionHeading">Hello</h1>
                     <h1 class="sectionHeading">Hello</h1>

--- a/storybook/index.html
+++ b/storybook/index.html
@@ -98,6 +98,15 @@
                     <h1 class="sectionHeading">Hello</h1>
                     <h1 class="sectionHeading">Hello</h1>
                 </div>
+                <div class="gridBox gridBox-col4">
+                    <h1 class="sectionHeading">Hello</h1>
+                    <h1 class="sectionHeading">Hello</h1>
+                    <h1 class="sectionHeading">Hello</h1>
+                    <h1 class="sectionHeading">Hello</h1>
+                    <h1 class="sectionHeading">Hello</h1>
+                    <h1 class="sectionHeading">Hello</h1>
+                    <h1 class="sectionHeading">Hello</h1>
+                </div>
             </section>
 
             <section class="demo" data-module-name="missionStatement">

--- a/storybook/index.html
+++ b/storybook/index.html
@@ -18,28 +18,32 @@
 
         <main class="l-main">
             <section class="demo" data-module-name="box">
+                <p class="sbVariant">.box</p>
                 <div class="box">
                     Hello
                 </div>
+                <p class="sbVariant">.box.box-red</p>
                 <div class="box box-red">
                     Hello
                 </div>
+                <p class="sbVariant">.box.box-blue</p>
                 <div class="box box-blue">
                     Hello
                 </div>
+                <p class="sbVariant">.box.box-yellow</p>
                 <div class="box box-yellow">
                     Hello
                 </div>
             </section>
 
             <section class="demo" data-module-name="btnLink">
-                <p>Small</p>
+                <p class="sbVariant">.btnLink.btnLink-small</p>
                 <a class="btnLink btnLink-small" href="https://www.youtube.com/watch?v=dQw4w9WgXcQ">Button</a>
                 <a class="btnLink btnLink-red btnLink-small">Button</a>
-                <p>Normal</p>
+                <p class="sbVariant">.btnLink</p>
                 <a class="btnLink">Button</a>
                 <a class="btnLink btnLink-red">Button</a>
-                <p>Large</p>
+                <p class="sbVariant">.btnLink.btnLink-large</p>
                 <a class="btnLink btnLink-large">Button</a>
                 <a class="btnLink btnLink-red btnLink-large">Button</a>
             </section>
@@ -76,11 +80,13 @@
             </section>
 
             <section class="demo" data-module-name="gridBox">
+                <p class="sbVariant">.gridBox.gridBox-col1</p>
                 <div class="gridBox gridBox-col1">
                     <div>
                         <h1 class="sectionHeading">Hello</h1>
                     </div>
                 </div>
+                <p class="sbVariant">.gridBox.gridBox-col2</p>
                 <div class="gridBox gridBox-col2">
                     <div>
                         <h1 class="sectionHeading">Hello</h1>
@@ -92,6 +98,7 @@
                         <h1 class="sectionHeading">Hello</h1>
                     </div>
                 </div>
+                <p class="sbVariant">.gridBox.gridBox-col3</p>
                 <div class="gridBox gridBox-col3">
                     <div>
                         <h1 class="sectionHeading">Hello</h1>

--- a/storybook/index.html
+++ b/storybook/index.html
@@ -32,6 +32,18 @@
                 </div>
             </section>
 
+            <section class="demo" data-module-name="btnLink">
+                <p>Small</p>
+                <a class="btnLink btnLink-small" href="https://www.youtube.com/watch?v=dQw4w9WgXcQ">Button</a>
+                <a class="btnLink btnLink-red btnLink-small">Button</a>
+                <p>Normal</p>
+                <a class="btnLink">Button</a>
+                <a class="btnLink btnLink-red">Button</a>
+                <p>Large</p>
+                <a class="btnLink btnLink-large">Button</a>
+                <a class="btnLink btnLink-red btnLink-large">Button</a>
+            </section>
+
             <section class="demo" data-module-name="faq">
                 <div class="faqContainer">
                     <div class="faq">
@@ -102,6 +114,15 @@
                 </div>
             </section>
 
+            <section class="demo" data-module-name="missionStatement">
+                <div class="missionStatement">
+                    <div class="missionStatement--logo">
+                        <img src="../images/logo-gold-border.svg">
+                    </div>
+                    <p>Our program is constantly establishing new standards of excellence in the practice of public and contemporary art creation and exhibition. Our collaborative dialogue processes empower artists and communities to address and organize issues in the community. Community art builds bridges from conceptual connection to a physical understanding. With close attention to our clients desires the results are beautiful murals that inspire and motivate viewers.</p>
+                </div>
+            </section>
+
             <section class="demo" data-module-name="scrollCarousel">
                 <div class="scrollCarousel">
                     <div class="scrollCarousel--contents">
@@ -159,15 +180,6 @@
                 </div>
             </section>
 
-            <section class="demo" data-module-name="missionStatement">
-                <div class="missionStatement">
-                    <div class="missionStatement--logo">
-                        <img src="../images/logo-gold-border.svg">
-                    </div>
-                    <p>Our program is constantly establishing new standards of excellence in the practice of public and contemporary art creation and exhibition. Our collaborative dialogue processes empower artists and communities to address and organize issues in the community. Community art builds bridges from conceptual connection to a physical understanding. With close attention to our clients desires the results are beautiful murals that inspire and motivate viewers.</p>
-                </div>
-            </section>
-
             <section class="demo" data-module-name="testimonial">
                 <div class="testimonial">
                     <div class="testimonial--pic">
@@ -178,18 +190,6 @@
                         <p class="testimonial--quote">“Whether I shall turn out to be the hero of my own life, or whether that station will be held by anybody else, these pages must show.”</p>
                     </div>
                 </div>
-            </section>
-
-            <section class="demo" data-module-name="btnLink">
-                <p>Small</p>
-                <a class="btnLink btnLink-small" href="https://www.youtube.com/watch?v=dQw4w9WgXcQ">Button</a>
-                <a class="btnLink btnLink-red btnLink-small">Button</a>
-                <p>Normal</p>
-                <a class="btnLink">Button</a>
-                <a class="btnLink btnLink-red">Button</a>
-                <p>Large</p>
-                <a class="btnLink btnLink-large">Button</a>
-                <a class="btnLink btnLink-red btnLink-large">Button</a>
             </section>
         </main>
     </body>

--- a/storybook/index.html
+++ b/storybook/index.html
@@ -10,195 +10,202 @@
         <script src="script.js" defer></script>
     </head>
 
-    <body class="l-body">
-        <nav class="l-sidebar">
-            <h2 class="sbHeading">Modules</h2>
-            <ul class="sbNavList"><!-- list items will be added dynamically --></ul>
-        </nav>
+    <body>
+        <div class="l-topbar">
+            <div class="sbTopbar">
+                <img class="sbTopbar--logo" src="../images/logo-gold-border.svg">
+                <h1>BAMP Website Storybook</h1>
+            </div>
+        </div>
+        <div class="l-container">
+            <nav class="l-sidebar">
+                <h2 class="sbHeading">Modules</h2>
+                <ul class="sbNavList"><!-- list items will be added dynamically --></ul>
+            </nav>
+            <main class="l-main">
+                <section class="demo" data-module-name="box">
+                    <p class="sbVariant">.box</p>
+                    <div class="box">
+                        Hello
+                    </div>
+                    <p class="sbVariant">.box.box-red</p>
+                    <div class="box box-red">
+                        Hello
+                    </div>
+                    <p class="sbVariant">.box.box-blue</p>
+                    <div class="box box-blue">
+                        Hello
+                    </div>
+                    <p class="sbVariant">.box.box-yellow</p>
+                    <div class="box box-yellow">
+                        Hello
+                    </div>
+                </section>
 
-        <main class="l-main">
-            <section class="demo" data-module-name="box">
-                <p class="sbVariant">.box</p>
-                <div class="box">
-                    Hello
-                </div>
-                <p class="sbVariant">.box.box-red</p>
-                <div class="box box-red">
-                    Hello
-                </div>
-                <p class="sbVariant">.box.box-blue</p>
-                <div class="box box-blue">
-                    Hello
-                </div>
-                <p class="sbVariant">.box.box-yellow</p>
-                <div class="box box-yellow">
-                    Hello
-                </div>
-            </section>
+                <section class="demo" data-module-name="btnLink">
+                    <p class="sbVariant">.btnLink.btnLink-small</p>
+                    <a class="btnLink btnLink-small" href="https://www.youtube.com/watch?v=dQw4w9WgXcQ">Button</a>
+                    <a class="btnLink btnLink-red btnLink-small">Button</a>
+                    <p class="sbVariant">.btnLink</p>
+                    <a class="btnLink">Button</a>
+                    <a class="btnLink btnLink-red">Button</a>
+                    <p class="sbVariant">.btnLink.btnLink-large</p>
+                    <a class="btnLink btnLink-large">Button</a>
+                    <a class="btnLink btnLink-red btnLink-large">Button</a>
+                </section>
 
-            <section class="demo" data-module-name="btnLink">
-                <p class="sbVariant">.btnLink.btnLink-small</p>
-                <a class="btnLink btnLink-small" href="https://www.youtube.com/watch?v=dQw4w9WgXcQ">Button</a>
-                <a class="btnLink btnLink-red btnLink-small">Button</a>
-                <p class="sbVariant">.btnLink</p>
-                <a class="btnLink">Button</a>
-                <a class="btnLink btnLink-red">Button</a>
-                <p class="sbVariant">.btnLink.btnLink-large</p>
-                <a class="btnLink btnLink-large">Button</a>
-                <a class="btnLink btnLink-red btnLink-large">Button</a>
-            </section>
-
-            <section class="demo" data-module-name="faq">
-                <div class="faqContainer">
-                    <div class="faq">
-                        <input id="q1" type="checkbox" class="faq--checkbox">
-                            <label for="q1" class="faq--question">
-                                What is the meaning of life?
-                                <div class="faq--plus">+</div>
-                            </label>
-                        <div class="faq--answers">
-                            Life is very complex, so just live the best life. Nothing really matters, just go go with the flow. We're all figuring it out as we go. Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.
+                <section class="demo" data-module-name="faq">
+                    <div class="faqContainer">
+                        <div class="faq">
+                            <input id="q1" type="checkbox" class="faq--checkbox">
+                                <label for="q1" class="faq--question">
+                                    What is the meaning of life?
+                                    <div class="faq--plus">+</div>
+                                </label>
+                            <div class="faq--answers">
+                                Life is very complex, so just live the best life. Nothing really matters, just go go with the flow. We're all figuring it out as we go. Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.
+                            </div>
+                        </div>
+                        <div class="faq">
+                            <input id="q2" type="checkbox" class="faq--checkbox">
+                                <label for="q2" class="faq--question">
+                                    What is the meaning of life?
+                                    <div class="faq--plus">+</div>
+                                </label>
+                            <div class="faq--answers">42</div>
+                        </div>
+                        <div class="faq">
+                            <input id="q3" type="checkbox" class="faq--checkbox">
+                                <label for="q3" class="faq--question">
+                                    What is the meaning of life?
+                                    <div class="faq--plus">+</div>
+                                </label>
+                            <div class="faq--answers">42</div>
                         </div>
                     </div>
-                    <div class="faq">
-                        <input id="q2" type="checkbox" class="faq--checkbox">
-                            <label for="q2" class="faq--question">
-                                What is the meaning of life?
-                                <div class="faq--plus">+</div>
-                            </label>
-                        <div class="faq--answers">42</div>
-                    </div>
-                    <div class="faq">
-                        <input id="q3" type="checkbox" class="faq--checkbox">
-                            <label for="q3" class="faq--question">
-                                What is the meaning of life?
-                                <div class="faq--plus">+</div>
-                            </label>
-                        <div class="faq--answers">42</div>
-                    </div>
-                </div>
-            </section>
+                </section>
 
-            <section class="demo" data-module-name="gridBox">
-                <p class="sbVariant">.gridBox.gridBox-col1</p>
-                <div class="gridBox gridBox-col1">
-                    <h1 class="sectionHeading">Hello</h1>
-                </div>
-                <p class="sbVariant">.gridBox.gridBox-col2</p>
-                <div class="gridBox gridBox-col2">
-                    <h1 class="sectionHeading">Hello</h1>
-                    <h1 class="sectionHeading">Hello</h1>
-                    <h1 class="sectionHeading">Hello</h1>
-                </div>
-                <p class="sbVariant">.gridBox.gridBox-col3</p>
-                <div class="gridBox gridBox-col3">
-                    <h1 class="sectionHeading">Hello</h1>
-                    <h1 class="sectionHeading">Hello</h1>
-                    <h1 class="sectionHeading">Hello</h1>
-                    <h1 class="sectionHeading">Hello</h1>
-                    <h1 class="sectionHeading">Hello</h1>
-                </div>
-                <p class="sbVariant">.gridBox.gridBox-col4</p>
-                <div class="gridBox gridBox-col4">
-                    <h1 class="sectionHeading">Hello</h1>
-                    <h1 class="sectionHeading">Hello</h1>
-                    <h1 class="sectionHeading">Hello</h1>
-                    <h1 class="sectionHeading">Hello</h1>
-                    <h1 class="sectionHeading">Hello</h1>
-                    <h1 class="sectionHeading">Hello</h1>
-                    <h1 class="sectionHeading">Hello</h1>
-                </div>
-                <p class="sbVariant">.gridBox.gridBox-col4.gridBox-center</p>
-                <div class="gridBox gridBox-col4 gridBox-center">
-                    <h1 class="sectionHeading">Hello</h1>
-                    <h1 class="sectionHeading">Hello</h1>
-                    <h1 class="sectionHeading">Hello</h1>
-                    <h1 class="sectionHeading">Hello</h1>
-                    <h1 class="sectionHeading">Hello</h1>
-                    <h1 class="sectionHeading">Hello</h1>
-                    <h1 class="sectionHeading">Hello</h1>
-                </div>
-            </section>
+                <section class="demo" data-module-name="gridBox">
+                    <p class="sbVariant">.gridBox.gridBox-col1</p>
+                    <div class="gridBox gridBox-col1">
+                        <h1 class="sectionHeading">Hello</h1>
+                    </div>
+                    <p class="sbVariant">.gridBox.gridBox-col2</p>
+                    <div class="gridBox gridBox-col2">
+                        <h1 class="sectionHeading">Hello</h1>
+                        <h1 class="sectionHeading">Hello</h1>
+                        <h1 class="sectionHeading">Hello</h1>
+                    </div>
+                    <p class="sbVariant">.gridBox.gridBox-col3</p>
+                    <div class="gridBox gridBox-col3">
+                        <h1 class="sectionHeading">Hello</h1>
+                        <h1 class="sectionHeading">Hello</h1>
+                        <h1 class="sectionHeading">Hello</h1>
+                        <h1 class="sectionHeading">Hello</h1>
+                        <h1 class="sectionHeading">Hello</h1>
+                    </div>
+                    <p class="sbVariant">.gridBox.gridBox-col4</p>
+                    <div class="gridBox gridBox-col4">
+                        <h1 class="sectionHeading">Hello</h1>
+                        <h1 class="sectionHeading">Hello</h1>
+                        <h1 class="sectionHeading">Hello</h1>
+                        <h1 class="sectionHeading">Hello</h1>
+                        <h1 class="sectionHeading">Hello</h1>
+                        <h1 class="sectionHeading">Hello</h1>
+                        <h1 class="sectionHeading">Hello</h1>
+                    </div>
+                    <p class="sbVariant">.gridBox.gridBox-col4.gridBox-center</p>
+                    <div class="gridBox gridBox-col4 gridBox-center">
+                        <h1 class="sectionHeading">Hello</h1>
+                        <h1 class="sectionHeading">Hello</h1>
+                        <h1 class="sectionHeading">Hello</h1>
+                        <h1 class="sectionHeading">Hello</h1>
+                        <h1 class="sectionHeading">Hello</h1>
+                        <h1 class="sectionHeading">Hello</h1>
+                        <h1 class="sectionHeading">Hello</h1>
+                    </div>
+                </section>
 
-            <section class="demo" data-module-name="missionStatement">
-                <div class="missionStatement">
-                    <div class="missionStatement--logo">
-                        <img src="../images/logo-gold-border.svg">
-                    </div>
-                    <p>Our program is constantly establishing new standards of excellence in the practice of public and contemporary art creation and exhibition. Our collaborative dialogue processes empower artists and communities to address and organize issues in the community. Community art builds bridges from conceptual connection to a physical understanding. With close attention to our clients desires the results are beautiful murals that inspire and motivate viewers.</p>
-                </div>
-            </section>
-
-            <section class="demo" data-module-name="scrollCarousel">
-                <div class="scrollCarousel">
-                    <div class="scrollCarousel--contents">
-                        <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
-                        <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
-                        <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
-                        <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
-                        <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
-                        <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
-                        <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
-                        <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
-                        <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
-                        <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
-                        <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
-                        <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
-                        <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
-                        <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
-                        <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
-                        <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
-                        <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
-                        <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
-                        <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
-                        <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
-                        <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
-                        <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
-                        <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
-                        <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
-                        <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
-                        <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
-                        <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
-                        <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
-                        <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
-                        <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
-                    </div>
-                </div>
-            </section>
-
-            <section class="demo" data-module-name="teamMember">
-                <div class="teamMember">
-                    <div class="teamMember--photo">
-                        <img src="https://fm.cnbc.com/applications/cnbc.com/resources/img/editorial/2020/09/09/106695701-1599664926959-gettyimages-1228423382-AFP_8PL8JF.600x400.jpeg?v=1599664969">
-                    </div>
-                    <div class="teamMember--name">
-                        Andre Jones
-                    </div>
-                    <div class="teamMember--role">
-                        BAMP Executive Director / <br> Lead Artist
-                    </div>
-                    <a class="teamMember--icon" href="#">
-                        <img src="../images/linkedin.svg">
-                    </a>
-                    <a class="teamMember--icon" href="#">
-                        <img src="../images/mail.svg">
-                    </a>
-                </div>
-            </section>
-
-            <section class="demo" data-module-name="testimonial">
-                <center>
-                    <div class="testimonial">
-                        <div class="testimonial--pic">
-                            <img src="https://cdn.pixabay.com/photo/2015/04/23/22/00/tree-736885__340.jpg">
+                <section class="demo" data-module-name="missionStatement">
+                    <div class="missionStatement">
+                        <div class="missionStatement--logo">
+                            <img src="../images/logo-gold-border.svg">
                         </div>
-                        <div class="testimonial--content">
-                            <span class="testimonial--name">Community Member</span>
-                            <p class="testimonial--quote">“Whether I shall turn out to be the hero of my own life, or whether that station will be held by anybody else, these pages must show.”</p>
+                        <p>Our program is constantly establishing new standards of excellence in the practice of public and contemporary art creation and exhibition. Our collaborative dialogue processes empower artists and communities to address and organize issues in the community. Community art builds bridges from conceptual connection to a physical understanding. With close attention to our clients desires the results are beautiful murals that inspire and motivate viewers.</p>
+                    </div>
+                </section>
+
+                <section class="demo" data-module-name="scrollCarousel">
+                    <div class="scrollCarousel">
+                        <div class="scrollCarousel--contents">
+                            <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
+                            <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
+                            <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
+                            <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
+                            <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
+                            <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
+                            <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
+                            <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
+                            <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
+                            <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
+                            <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
+                            <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
+                            <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
+                            <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
+                            <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
+                            <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
+                            <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
+                            <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
+                            <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
+                            <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
+                            <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
+                            <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
+                            <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
+                            <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
+                            <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
+                            <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
+                            <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
+                            <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
+                            <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
+                            <img src="https://static.wixstatic.com/media/d45a2e_9d25ee533e854c1ba4b3007f1789f6b4~mv2.jpg">
                         </div>
                     </div>
-                </center>
-            </section>
-        </main>
+                </section>
+
+                <section class="demo" data-module-name="teamMember">
+                    <div class="teamMember">
+                        <div class="teamMember--photo">
+                            <img src="https://fm.cnbc.com/applications/cnbc.com/resources/img/editorial/2020/09/09/106695701-1599664926959-gettyimages-1228423382-AFP_8PL8JF.600x400.jpeg?v=1599664969">
+                        </div>
+                        <div class="teamMember--name">
+                            Andre Jones
+                        </div>
+                        <div class="teamMember--role">
+                            BAMP Executive Director / <br> Lead Artist
+                        </div>
+                        <a class="teamMember--icon" href="#">
+                            <img src="../images/linkedin.svg">
+                        </a>
+                        <a class="teamMember--icon" href="#">
+                            <img src="../images/mail.svg">
+                        </a>
+                    </div>
+                </section>
+
+                <section class="demo" data-module-name="testimonial">
+                    <center>
+                        <div class="testimonial">
+                            <div class="testimonial--pic">
+                                <img src="https://cdn.pixabay.com/photo/2015/04/23/22/00/tree-736885__340.jpg">
+                            </div>
+                            <div class="testimonial--content">
+                                <span class="testimonial--name">Community Member</span>
+                                <p class="testimonial--quote">“Whether I shall turn out to be the hero of my own life, or whether that station will be held by anybody else, these pages must show.”</p>
+                            </div>
+                        </div>
+                    </center>
+                </section>
+            </main>
+        </div>
     </body>
 </html>

--- a/storybook/index.html
+++ b/storybook/index.html
@@ -82,42 +82,21 @@
             <section class="demo" data-module-name="gridBox">
                 <p class="sbVariant">.gridBox.gridBox-col1</p>
                 <div class="gridBox gridBox-col1">
-                    <div>
-                        <h1 class="sectionHeading">Hello</h1>
-                    </div>
+                    <h1 class="sectionHeading">Hello</h1>
                 </div>
                 <p class="sbVariant">.gridBox.gridBox-col2</p>
                 <div class="gridBox gridBox-col2">
-                    <div>
-                        <h1 class="sectionHeading">Hello</h1>
-                    </div>
-                    <div>
-                        <h1 class="sectionHeading">Hello</h1>
-                    </div>
-                    <div>
-                        <h1 class="sectionHeading">Hello</h1>
-                    </div>
+                    <h1 class="sectionHeading">Hello</h1>
+                    <h1 class="sectionHeading">Hello</h1>
+                    <h1 class="sectionHeading">Hello</h1>
                 </div>
                 <p class="sbVariant">.gridBox.gridBox-col3</p>
                 <div class="gridBox gridBox-col3">
-                    <div>
-                        <h1 class="sectionHeading">Hello</h1>
-                    </div>
-                    <div>
-                        <h1 class="sectionHeading">Hello</h1>
-                    </div>
-                    <div>
-                        <h1 class="sectionHeading">Hello</h1>
-                    </div>
-                    <div>
-                        <h1 class="sectionHeading">Hello</h1>
-                    </div>
-                    <div>
-                        <h1 class="sectionHeading">Hello</h1>
-                    </div>
-                    <div>
-                        <h1 class="sectionHeading">Hello</h1>
-                    </div>
+                    <h1 class="sectionHeading">Hello</h1>
+                    <h1 class="sectionHeading">Hello</h1>
+                    <h1 class="sectionHeading">Hello</h1>
+                    <h1 class="sectionHeading">Hello</h1>
+                    <h1 class="sectionHeading">Hello</h1>
                 </div>
             </section>
 

--- a/storybook/script.js
+++ b/storybook/script.js
@@ -11,17 +11,30 @@ const titlebar = () =>
 
 const page = contents => {
     const inner = $('<div>').addClass('sbPage--inner').append(contents)
-    const div = $('<div>').addClass('sbPage').append(titlebar(), inner)
-    return div
+    return $('<div>').addClass('sbPage').append(titlebar(), inner)
+}
+
+const bookmark = moduleName =>
+    $('<a>').prop('name', moduleName)
+
+const navItem = moduleName => {
+    const item = $('<li>').addClass('sbNavList--item')
+    const link = $('<a>').prop('href', '#' + moduleName).text(moduleName)
+    return item.append(link)
 }
 
 
+const nav = $('nav ul')
+
 for (const section of $('.demo')) {
     const contents = $(section).children()
-    const h1text = contents[0].classList[0]
+    const moduleName = $(section).data('module-name')
 
     $(section).empty().append([
-        heading(h1text),
+        bookmark(moduleName),
+        heading(moduleName),
         page(contents)
     ])
+
+    $(nav).append(navItem(moduleName))
 }

--- a/storybook/style.css
+++ b/storybook/style.css
@@ -163,6 +163,5 @@ section .sbHeading {
     box-sizing: border-box;
     padding: 8px;
     border: 2px dashed #508EFF;
-    height: 100px;
     border-radius: 8px;
 }

--- a/storybook/style.css
+++ b/storybook/style.css
@@ -67,6 +67,15 @@ section + section {
     background-color: #f9f9f9;
 }
 
+/* .sbVariant module */
+
+.sbVariant {
+    font-size: 12px;
+    color: gray;
+    font-family: monospace;
+    line-height: 200%;
+}
+
 
 /* .sbHeading module */
 

--- a/storybook/style.css
+++ b/storybook/style.css
@@ -1,12 +1,76 @@
-/* base */
+/* base rules */
 
 body {
     font-family: 'ibm plex sans';
+    margin: 0;
+    padding: 0;
 }
 
 section {
-    padding: 24px;
+    padding: 36px 24px;
 }
+
+
+/* layout rules */
+
+.l-body {
+    display: flex;
+    justify-content: space-between;
+}
+
+.l-sidebar {
+    flex: 0 0 200px;
+    height: 100vh;
+    padding-left: 16px;
+    position: sticky;
+    top: 0;
+}
+
+.l-main {
+    flex: 0 1 auto;
+    min-width: 0;
+}
+
+@media (max-width: 620px) {
+    .l-nav {
+        display: none;
+    }
+}
+
+
+/* .sbNavHeading module */
+
+.sbNavHeading {
+    font-size: 22px;
+    margin-bottom: 8px;
+}
+
+
+/* .sbNavList module */
+
+.sbNavList {
+    padding-left: 0;
+    margin: 0;
+}
+
+.sbNavList--item {
+    font-size: 18px;
+    list-style-type: none;
+}
+
+.sbNavList--item > a {
+    display: block;
+    width: 100%;
+    text-decoration: none;
+    line-height: 200%;
+    color: #113255;
+}
+
+.sbNavList--item > a:hover {
+    font-weight: bold;
+    background-color: #f9f9f9;
+}
+
 
 /* .sbHeading module */
 
@@ -19,6 +83,7 @@ section {
 section .sbHeading {
     margin-bottom: 8px;
 }
+
 
 /* .sbPage module */
 
@@ -72,6 +137,7 @@ section .sbHeading {
         display: none;
     }
 }
+
 
 /* ---- extra styles for module demos ---- */
 

--- a/storybook/style.css
+++ b/storybook/style.css
@@ -36,7 +36,7 @@ section + section {
 }
 
 @media (max-width: 620px) {
-    .l-nav {
+    .l-sidebar {
         display: none;
     }
 }

--- a/storybook/style.css
+++ b/storybook/style.css
@@ -91,6 +91,7 @@ h1, h2, h3 {
     background-color: #f9f9f9;
 }
 
+
 /* .sbVariant module */
 
 .sbVariant {

--- a/storybook/style.css
+++ b/storybook/style.css
@@ -7,17 +7,25 @@ body {
 }
 
 section {
-    padding: 18px 24px;
+    padding: 0 24px 24px;
 }
 
 section + section {
     padding-top: 36px;
 }
 
+h1, h2, h3 {
+    font-family: "Libre Franklin";
+}
+
 
 /* layout rules */
 
-.l-body {
+.l-topbar {
+    margin: 16px;
+}
+
+.l-container {
     display: flex;
     justify-content: space-between;
 }
@@ -39,6 +47,19 @@ section + section {
     .l-sidebar {
         display: none;
     }
+}
+
+
+/* .sbTopbar module */
+
+.sbTopbar {
+    display: flex;
+    align-items: center;
+}
+
+.sbTopbar--logo {
+    width: 50px;
+    margin-right: 12px;
 }
 
 

--- a/storybook/style.css
+++ b/storybook/style.css
@@ -156,7 +156,7 @@ section .sbHeading {
 }
 
 .demo[data-module-name="gridBox"] .gridBox {
-    margin-bottom: 48px;
+    margin-bottom: 24px;
 }
 
 .demo[data-module-name="gridBox"] .gridBox > * {

--- a/storybook/style.css
+++ b/storybook/style.css
@@ -148,16 +148,21 @@ section .sbHeading {
 
 /* ---- extra styles for module demos ---- */
 
-.sbPage .box {
+.demo[data-module-name="box"] .box {
     margin-bottom: 24px;
+    display: block !important;
+    padding: 16px;
+    min-width: 45vw;
 }
 
-.sbPage .gridBox {
+.demo[data-module-name="gridBox"] .gridBox {
     margin-bottom: 48px;
 }
 
-.sbPage .gridBox > * {
-    background: #508EFF;
+.demo[data-module-name="gridBox"] .gridBox > * {
+    box-sizing: border-box;
+    padding: 8px;
+    border: 2px dashed #508EFF;
     height: 100px;
-    border-radius: 10px;
+    border-radius: 8px;
 }

--- a/storybook/style.css
+++ b/storybook/style.css
@@ -7,7 +7,11 @@ body {
 }
 
 section {
-    padding: 36px 24px;
+    padding: 18px 24px;
+}
+
+section + section {
+    padding-top: 36px;
 }
 
 
@@ -23,7 +27,7 @@ section {
     height: 100vh;
     padding-left: 16px;
     position: sticky;
-    top: 0;
+    top: 18px;
 }
 
 .l-main {
@@ -35,14 +39,6 @@ section {
     .l-nav {
         display: none;
     }
-}
-
-
-/* .sbNavHeading module */
-
-.sbNavHeading {
-    font-size: 22px;
-    margin-bottom: 8px;
 }
 
 
@@ -76,8 +72,10 @@ section {
 
 .sbHeading {
     width: max-content;
-    font-size: 20px;
+    font-size: 22px;
     font-weight: bold;
+    line-height: 200%;
+    margin: 0;
 }
 
 section .sbHeading {

--- a/storybook/style.css
+++ b/storybook/style.css
@@ -1,3 +1,6 @@
+@import url('https://fonts.googleapis.com/css2?family=Courier+Prime:ital,wght@1,700&display=swap');
+
+
 /* base rules */
 
 body {
@@ -93,8 +96,10 @@ h1, h2, h3 {
 .sbVariant {
     font-size: 12px;
     color: gray;
-    font-family: monospace;
+    font-family: 'courier prime', monospace;
     line-height: 200%;
+    font-weight: bold;
+    font-style: italic;
 }
 
 

--- a/style/modules/box.css
+++ b/style/modules/box.css
@@ -1,6 +1,7 @@
 .box {
     background: #F5F5F5;
     box-shadow: 6px 6px 0px #303030;
+    width: max-content;
 }
 
 .box-red {
@@ -16,6 +17,10 @@
 }
 
 @media screen and (max-width: 600px) {
+    .box {
+        box-shadow: 4px 4px 0px #303030;
+    }
+
     .box-red {
         box-shadow: 4px 4px 0px #FF6D6D;
     }

--- a/style/modules/gridBox.css
+++ b/style/modules/gridBox.css
@@ -8,6 +8,10 @@
     margin: 5px; /* the space between blocks. Doesn't affect on the components inside the blocks */
 }
 
+.gridBox-center {
+    justify-content: center;
+}
+
 /* columns */
 
 .gridBox-col1 > * {

--- a/style/modules/gridBox.css
+++ b/style/modules/gridBox.css
@@ -15,9 +15,9 @@
 }
 
 .gridBox-col2 > * {
-    flex-basis: 45%;
+    flex-basis: 48%;
 }
 
 .gridBox-col3 > * {
-    flex-basis: 30%;
+    flex-basis: 32%;
 }

--- a/style/modules/gridBox.css
+++ b/style/modules/gridBox.css
@@ -21,3 +21,7 @@
 .gridBox-col3 > * {
     flex-basis: 32%;
 }
+
+.gridBox-col4 > * {
+    flex-basis: 23%;
+}

--- a/style/modules/missionStatement.css
+++ b/style/modules/missionStatement.css
@@ -1,4 +1,5 @@
 .missionStatement {
+    position: relative;
     max-width: 60%;
     margin: 0 auto;
     margin-top: 110px;
@@ -18,8 +19,7 @@
     width: 200px;
     background-color: white;
     left: 50%;
-    transform: translateY(-110px);
-    margin-left: -120px;
+    transform: translate(-50%, -50%);
 }
 
 .missionStatement > p {

--- a/style/modules/scrollCarousel.css
+++ b/style/modules/scrollCarousel.css
@@ -8,7 +8,7 @@
     display: flex;
     animation-direction: alternate;
     animation-name: moveSlideshow;
-    animation-duration: 25s;
+    animation-duration: 60s;
     animation-timing-function: linear;
     animation-iteration-count: infinite;
 

--- a/style/modules/scrollCarousel.css
+++ b/style/modules/scrollCarousel.css
@@ -11,7 +11,6 @@
     animation-duration: 60s;
     animation-timing-function: linear;
     animation-iteration-count: infinite;
-
 }
 
 .scrollCarousel--contents > * {

--- a/style/modules/teamMember.css
+++ b/style/modules/teamMember.css
@@ -61,11 +61,7 @@
         border-radius: 50%;
     }
 
-    .teamMember--linkedin {
-        display: none;
-    }
-
-    .teamMember--mail {
+    .teamMember--icon {
         display: none;
     }
 }


### PR DESCRIPTION
<img width="972" alt="Screen Shot 2020-09-18 at 10 06 52 AM" src="https://user-images.githubusercontent.com/733916/93625454-d3ad9300-f996-11ea-8ccf-726d2f70dc43.png">



This PR:

* **improves the storybook by adding a left navbar.** you can click the modules names to scroll to each one
* changes the way module names are figured out (**demos now need the `data-module-name` tag, must be added manually**)
* establishes a consistent look for variant names
* changes the appearance of the `gridBox` contents in that demo, to make it more obvious to BAMP that they're "empty"
* centers the `testimonial` demo

I also made some module changes to polish things before showing BAMP:

* adds `gridBox-col4` and `gridBox-center`
* tweaks `box` to size to its contents
* fixes a positioning glitch with `missionStatement` that only happens when the page contents are not centered
* fixes the hiding of `teamMember--icon`
* slows `scrollCarousel` speed