### PR TITLE
Tweak shared components

### DIFF
--- a/storybook/style.css
+++ b/storybook/style.css
@@ -46,7 +46,7 @@ h1, h2, h3 {
     min-width: 0;
 }
 
-@media (max-width: 620px) {
+@media (max-width: 800px) {
     .l-sidebar {
         display: none;
     }

--- a/style/modules/btnLink.css
+++ b/style/modules/btnLink.css
@@ -15,6 +15,7 @@
     transition: 150ms;
     user-select: none;
     text-decoration: none;
+    white-space: nowrap;
 }
 
 .btnLink:hover {

--- a/style/modules/gridBox.css
+++ b/style/modules/gridBox.css
@@ -5,7 +5,8 @@
 
 .gridBox > * {  /* applies to all the items in the grid */
     vertical-align: top;
-    margin: 5px; /* the space between blocks. Doesn't affect on the components inside the blocks */
+    margin: 12px; /* the space between blocks. Doesn't affect on the components inside the blocks */
+    box-sizing: border-box;
 }
 
 .gridBox-center {
@@ -19,13 +20,13 @@
 }
 
 .gridBox-col2 > * {
-    flex-basis: 48%;
+    flex-basis: 45%;
 }
 
 .gridBox-col3 > * {
-    flex-basis: 32%;
+    flex-basis: 30%;
 }
 
 .gridBox-col4 > * {
-    flex-basis: 23%;
+    flex-basis: 22%;
 }

--- a/style/modules/gridBox.css
+++ b/style/modules/gridBox.css
@@ -5,7 +5,7 @@
 
 .gridBox > * {  /* applies to all the items in the grid */
     vertical-align: top;
-    margin: 12px; /* the space between blocks. Doesn't affect on the components inside the blocks */
+    margin: 12px;
     box-sizing: border-box;
 }
 


### PR DESCRIPTION
I was playing around with the `.event` demo and realized we'll need a couple more tweaks before laying that out on the events page. This PR:

* prevents text inside of `.btnLink` from wrapping
* increases space between `.gridBox` elements

It also hides the storybook sidebar earlier (at a wider screen width).
