### PR TITLE
Delint CSS

### DIFF
--- a/.stylelintrc.yaml
+++ b/.stylelintrc.yaml
@@ -1,0 +1,5 @@
+extends: stylelint-config-standard
+rules:
+  indentation: 4
+  color-hex-length: null
+  no-empty-source: null

--- a/style/base.css
+++ b/style/base.css
@@ -6,7 +6,8 @@ p {
     font-family: 'IBM Plex Sans', sans-serif;
 }
 
-button, input[type="submit"] {
+button,
+input[type="submit"] {
     border: none;
     background: none;
 }

--- a/style/modules/box.css
+++ b/style/modules/box.css
@@ -1,19 +1,19 @@
 .box {
-    background: #F5F5F5;
+    background: #f5f5f5;
     box-shadow: 6px 6px 0 #303030;
     display: inline-block;
 }
 
 .box-red {
-    box-shadow: 6px 6px 0 #FF6D6D;
+    box-shadow: 6px 6px 0 #ff6d6d;
 }
 
 .box-blue {
-    box-shadow: 6px 6px 0 #6DA0FF;
+    box-shadow: 6px 6px 0 #6da0ff;
 }
 
 .box-yellow {
-    box-shadow: 6px 6px 0 #F7E85D;
+    box-shadow: 6px 6px 0 #f7e85d;
 }
 
 @media screen and (max-width: 600px) {
@@ -22,14 +22,14 @@
     }
 
     .box-red {
-        box-shadow: 4px 4px 0 #FF6D6D;
+        box-shadow: 4px 4px 0 #ff6d6d;
     }
 
     .box-blue {
-        box-shadow: 4px 4px 0 #6DA0FF;
+        box-shadow: 4px 4px 0 #6da0ff;
     }
 
     .box-yellow {
-        box-shadow: 4px 4px 0 #F7E85D;
+        box-shadow: 4px 4px 0 #f7e85d;
     }
 }

--- a/style/modules/box.css
+++ b/style/modules/box.css
@@ -1,35 +1,35 @@
 .box {
     background: #F5F5F5;
-    box-shadow: 6px 6px 0px #303030;
+    box-shadow: 6px 6px 0 #303030;
     display: inline-block;
 }
 
 .box-red {
-    box-shadow: 6px 6px 0px #FF6D6D;
+    box-shadow: 6px 6px 0 #FF6D6D;
 }
 
 .box-blue {
-    box-shadow: 6px 6px 0px #6DA0FF;
+    box-shadow: 6px 6px 0 #6DA0FF;
 }
 
 .box-yellow {
-    box-shadow: 6px 6px 0px #F7E85D;
+    box-shadow: 6px 6px 0 #F7E85D;
 }
 
 @media screen and (max-width: 600px) {
     .box {
-        box-shadow: 4px 4px 0px #303030;
+        box-shadow: 4px 4px 0 #303030;
     }
 
     .box-red {
-        box-shadow: 4px 4px 0px #FF6D6D;
+        box-shadow: 4px 4px 0 #FF6D6D;
     }
 
     .box-blue {
-        box-shadow: 4px 4px 0px #6DA0FF;
+        box-shadow: 4px 4px 0 #6DA0FF;
     }
 
     .box-yellow {
-        box-shadow: 4px 4px 0px #F7E85D;
+        box-shadow: 4px 4px 0 #F7E85D;
     }
 }

--- a/style/modules/btnLink.css
+++ b/style/modules/btnLink.css
@@ -4,8 +4,8 @@
 
 .btnLink {
     display: inline-block;
-    background: #3D81FF;
-    color: #FFFFFF;
+    background: #3d81ff;
+    color: #ffffff;
     padding: 5px 15px;
     border-radius: 100px;
     opacity: 100%;
@@ -28,7 +28,7 @@
 }
 
 .btnLink-red {
-    background: #FF3D3D;
+    background: #ff3d3d;
 }
 
 .btnLink-small {

--- a/style/modules/btnLink.css
+++ b/style/modules/btnLink.css
@@ -1,7 +1,3 @@
-.btnLink + .btnLink {
-    margin-left: 8px;
-}
-
 .btnLink {
     display: inline-block;
     background: #3d81ff;
@@ -16,6 +12,10 @@
     user-select: none;
     text-decoration: none;
     white-space: nowrap;
+}
+
+.btnLink + .btnLink {
+    margin-left: 8px;
 }
 
 .btnLink:hover {

--- a/style/modules/emailForm.css
+++ b/style/modules/emailForm.css
@@ -32,8 +32,8 @@
 }
 
 .emailForm--inputBox:invalid:focus:not(:placeholder-shown) {
-    box-shadow: 0 0 5px rgba(228, 72, 72, .5);
-    border-color: rgba(228, 72, 72, .5);
+    box-shadow: 0 0 5px rgba(228, 72, 72, 0.5);
+    border-color: rgba(228, 72, 72, 0.5);
 }
 
 .emailForm--inputBox:focus,

--- a/style/modules/emailForm.css
+++ b/style/modules/emailForm.css
@@ -31,15 +31,15 @@
     color: gray;
 }
 
-.emailForm--inputBox:invalid:focus:not(:placeholder-shown) {
-    box-shadow: 0 0 5px rgba(228, 72, 72, 0.5);
-    border-color: rgba(228, 72, 72, 0.5);
-}
-
 .emailForm--inputBox:focus,
 textarea:focus {
     box-shadow: 0 0 5px rgba(81, 203, 238, 1);
     border-color: rgba(81, 203, 238, 1);
+}
+
+.emailForm--inputBox:invalid:focus:not(:placeholder-shown) {
+    box-shadow: 0 0 5px rgba(228, 72, 72, 0.5);
+    border-color: rgba(228, 72, 72, 0.5);
 }
 
 @media only screen and (max-width: 600px) {

--- a/style/modules/emailForm.css
+++ b/style/modules/emailForm.css
@@ -14,9 +14,9 @@
     width: 100%;
     padding: 12px;
     margin-bottom: 20px;
-    border: 2px solid #BBBBBB;
+    border: 2px solid #bbbbbb;
     border-radius: 5px;
-    background: #EEEEEE;
+    background: #eeeeee;
     box-sizing: border-box;
     text-align: center;
     font-size: 20px;

--- a/style/modules/emailForm.css
+++ b/style/modules/emailForm.css
@@ -23,7 +23,7 @@
     outline: none;
     transition: 150ms;
     box-shadow: none;
-    font-family: 'IBM Plex Sans';
+    font-family: "IBM Plex Sans", sans-serif;
 }
 
 .emailForm--inputBox::placeholder {

--- a/style/modules/emailForm.css
+++ b/style/modules/emailForm.css
@@ -23,7 +23,7 @@
     outline: none;
     transition: 150ms;
     box-shadow: none;
-    font-family: 'IBM Plex Sans'
+    font-family: 'IBM Plex Sans';
 }
 
 .emailForm--inputBox::placeholder {

--- a/style/modules/event.css
+++ b/style/modules/event.css
@@ -10,7 +10,7 @@
 }
 
 .event--title {
-    padding: 0px 40px 0px;
+    padding: 0 40px;
     color: #113255;
     font-family: "Libre Franklin";
     font-size: 25px;
@@ -18,7 +18,7 @@
 
 .event--text {
     font-size: 17px;
-    padding: 0px 40px 0px;
+    padding: 0 40px;
     color: #303030;
 }
 
@@ -31,7 +31,7 @@
     color: #113255;
     font-family: "Libre Franklin";
     font-size: 20px;
-    flex-grow: .5;
+    flex-grow: 0.5;
     padding-left: 40px;
 }
 
@@ -42,7 +42,7 @@
 }
 
 .event--btn {
-    flex-grow: .5;
+    flex-grow: 0.5;
     padding-right: 20px;
 }
 
@@ -62,13 +62,13 @@
     }
 
     .event--title {
-        padding: 0px 30px 0px;
+        padding: 0 30px;
         font-size: 16px;
     }
 
     .event--text {
         font-size: 13px;
-        padding: 0px 30px 0px;
+        padding: 0 30px;
     }
 
     .event--dateTitle {

--- a/style/modules/event.css
+++ b/style/modules/event.css
@@ -12,7 +12,7 @@
 .event--title {
     padding: 0 40px;
     color: #113255;
-    font-family: "Libre Franklin";
+    font-family: "Libre Franklin", sans-serif;
     font-size: 25px;
 }
 
@@ -29,7 +29,7 @@
 
 .event--dateTitle {
     color: #113255;
-    font-family: "Libre Franklin";
+    font-family: "Libre Franklin", sans-serif;
     font-size: 20px;
     flex-grow: 0.5;
     padding-left: 40px;

--- a/style/modules/faq.css
+++ b/style/modules/faq.css
@@ -21,7 +21,7 @@
     display: block;
     width: 100%;
     cursor: pointer;
-    font-size: 20px
+    font-size: 20px;
 }
 
 .faq--answers {

--- a/style/modules/faq.css
+++ b/style/modules/faq.css
@@ -28,7 +28,7 @@
     font-size: 15px;
     display: block;
     max-height: 0;
-    transition: .3s ease;
+    transition: 0.3s ease;
     visibility: hidden;
     overflow-y: hidden;
     padding: 0 14px;
@@ -46,7 +46,7 @@
     float: right;
     font-size: 32px;
     line-height: 20px;
-    transition: .2s ease;
+    transition: 0.2s ease;
     user-select: none;
 }
 

--- a/style/modules/faq.css
+++ b/style/modules/faq.css
@@ -4,7 +4,7 @@
 }
 
 .faq {
-    background-color: #FFFFFF;
+    background-color: #ffffff;
     border: 2px solid #113255;
     border-color: #113255;
     border-style: solid;

--- a/style/modules/infoCard.css
+++ b/style/modules/infoCard.css
@@ -14,7 +14,7 @@
 
 .infoCard--title {
     color: #113255;
-    font-family: "Libre Franklin";
+    font-family: "Libre Franklin", sans-serif;
     font-size: 40px;
     margin: 0;
     padding-bottom: 15px;

--- a/style/modules/muralThumbnail.css
+++ b/style/modules/muralThumbnail.css
@@ -21,5 +21,5 @@
 }
 
 .muralThumbnail:hover {
-    opacity: .5;
+    opacity: 0.5;
 }

--- a/style/modules/pageHeader.css
+++ b/style/modules/pageHeader.css
@@ -20,7 +20,7 @@
 }
 
 .pageHeader--text {
-    color: #7C7C7C;
+    color: #7c7c7c;
     font-size: 28px;
     margin-top: 30px;
     margin-bottom: 0;

--- a/style/modules/pageHeader.css
+++ b/style/modules/pageHeader.css
@@ -28,7 +28,7 @@
 
 @media only screen and (max-width: 600px) {
     .pageHeader {
-        padding: 0px;
+        padding: 0;
     }
 
     .pageHeader > .box {

--- a/style/modules/program.css
+++ b/style/modules/program.css
@@ -16,7 +16,7 @@
 
 .program--title {
     color: #113255;
-    font-family: "Libre Franklin";
+    font-family: "Libre Franklin", sans-serif;
     font-size: 30px;
 }
 

--- a/style/modules/sectionHeading.css
+++ b/style/modules/sectionHeading.css
@@ -1,5 +1,5 @@
 .sectionHeading {
-    font-family: "libre franklin";
+    font-family: "Libre Franklin", sans-serif;
     font-weight: 700;
     color: #113255;
     font-size: 48px;


### PR DESCRIPTION
This PR unifies code style across the CSS files. Shouldn't change any behavior (although we were missing a couple of semicolons, so maybe?)

Done using the very cool `stylelint`: https://stylelint.io/

**Everyone please install this VS code extension -- https://marketplace.visualstudio.com/items?itemName=stylelint.vscode-stylelint**

Specific things:

- starts decimal numbers with a leading zero, for easier reading (`0.5` vs. `.5`)
- removes units from zeros (`0px` becomes `0`)
- lowercases RGB codes
- adds missing semicolons
- sorts rulesets by specificity (e.g. `a` should come before `a:hover`)
- where a ruleset has multiple selectors, puts each selector on its own line
- adds the `sans-serif` fallback wherever we specify IBM Plex or Franklin
  - this one might slightly improve the look before the fonts have loaded? didn't test that though
- adds a config file for `stylelint` to the project root