### PR TITLE
Use color variables everywhere

### DIFF
--- a/storybook/style.css
+++ b/storybook/style.css
@@ -189,6 +189,6 @@ section .sbHeading {
 .demo[data-module-name="gridBox"] .gridBox > * {
     box-sizing: border-box;
     padding: 8px;
-    border: 2px dashed #508EFF;
+    border: 2px dashed var(--light-blue);
     border-radius: 8px;
 }

--- a/storybook/style.css
+++ b/storybook/style.css
@@ -83,7 +83,7 @@ h1, h2, h3 {
     width: 100%;
     text-decoration: none;
     line-height: 200%;
-    color: #113255;
+    color: --var(dark-blue);
 }
 
 .sbNavList--item > a:hover {

--- a/storybook/style.css
+++ b/storybook/style.css
@@ -83,7 +83,7 @@ h1, h2, h3 {
     width: 100%;
     text-decoration: none;
     line-height: 200%;
-    color: --var(dark-blue);
+    color: var(--dark-blue);
 }
 
 .sbNavList--item > a:hover {

--- a/storybook/style.css
+++ b/storybook/style.css
@@ -96,7 +96,7 @@ h1, h2, h3 {
 
 .sbVariant {
     font-size: 12px;
-    color: gray;
+    color: var(--gray);
     font-family: 'courier prime', monospace;
     line-height: 200%;
     font-weight: bold;

--- a/storybook/style.css
+++ b/storybook/style.css
@@ -127,7 +127,7 @@ section .sbHeading {
 }
 
 .sbPage--titlebar {
-    background-color: #ddd;
+    background-color: var(--silver);
     height: 24px;
     border-top-left-radius: 6px;
     border-top-right-radius: 6px;

--- a/storybook/style.css
+++ b/storybook/style.css
@@ -1,10 +1,9 @@
 @import url('https://fonts.googleapis.com/css2?family=Courier+Prime:ital,wght@1,700&display=swap');
 
-
 /* base rules */
 
 body {
-    font-family: 'ibm plex sans';
+    font-family: 'ibm plex sans', sans-serif;
     margin: 0;
     padding: 0;
 }
@@ -17,10 +16,11 @@ section + section {
     padding-top: 36px;
 }
 
-h1, h2, h3 {
-    font-family: "Libre Franklin";
+h1,
+h2,
+h3 {
+    font-family: "Libre Franklin", sans-serif;
 }
-
 
 /* layout rules */
 
@@ -52,7 +52,6 @@ h1, h2, h3 {
     }
 }
 
-
 /* .sbTopbar module */
 
 .sbTopbar {
@@ -64,7 +63,6 @@ h1, h2, h3 {
     width: 50px;
     margin-right: 12px;
 }
-
 
 /* .sbNavList module */
 
@@ -91,7 +89,6 @@ h1, h2, h3 {
     background-color: #f9f9f9;
 }
 
-
 /* .sbVariant module */
 
 .sbVariant {
@@ -102,7 +99,6 @@ h1, h2, h3 {
     font-weight: bold;
     font-style: italic;
 }
-
 
 /* .sbHeading module */
 
@@ -117,7 +113,6 @@ h1, h2, h3 {
 section .sbHeading {
     margin-bottom: 8px;
 }
-
 
 /* .sbPage module */
 
@@ -137,6 +132,7 @@ section .sbHeading {
     border-top-left-radius: 6px;
     border-top-right-radius: 6px;
 }
+
 .sbPage--yellowBtn,
 .sbPage--greenBtn,
 .sbPage--redBtn {
@@ -171,7 +167,6 @@ section .sbHeading {
         display: none;
     }
 }
-
 
 /* ---- extra styles for module demos ---- */
 

--- a/style/index.css
+++ b/style/index.css
@@ -1,7 +1,10 @@
 @import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:ital,wght@0,400;0,600;0,700;1,400;1,700&display=swap');
 @import url('https://fonts.googleapis.com/css2?family=Libre+Franklin:wght@700&display=swap');
+
+@import url('variables.css');
 @import url('base.css');
 @import url('layout.css');
+
 @import url('modules/sectionHeading.css');
 @import url('modules/box.css');
 @import url('modules/gridBox.css');

--- a/style/modules/box.css
+++ b/style/modules/box.css
@@ -13,7 +13,7 @@
 }
 
 .box-yellow {
-    box-shadow: 6px 6px 0 #f7e85d;
+    box-shadow: 6px 6px 0 var(--yellow);
 }
 
 @media screen and (max-width: 600px) {
@@ -30,6 +30,6 @@
     }
 
     .box-yellow {
-        box-shadow: 4px 4px 0 #f7e85d;
+        box-shadow: 4px 4px 0 var(--yellow);
     }
 }

--- a/style/modules/box.css
+++ b/style/modules/box.css
@@ -1,6 +1,6 @@
 .box {
     background: #f5f5f5;
-    box-shadow: 6px 6px 0 #303030;
+    box-shadow: 6px 6px 0 var(--dark-gray);
     display: inline-block;
 }
 
@@ -18,7 +18,7 @@
 
 @media screen and (max-width: 600px) {
     .box {
-        box-shadow: 4px 4px 0 #303030;
+        box-shadow: 4px 4px 0 var(--dark-gray);
     }
 
     .box-red {

--- a/style/modules/btnLink.css
+++ b/style/modules/btnLink.css
@@ -1,6 +1,6 @@
 .btnLink {
     display: inline-block;
-    background: #3d81ff;
+    background: #3d81ff !important;
     color: var(--white);
     padding: 5px 15px;
     border-radius: 100px;

--- a/style/modules/btnLink.css
+++ b/style/modules/btnLink.css
@@ -1,7 +1,7 @@
 .btnLink {
     display: inline-block;
     background: #3d81ff;
-    color: #ffffff;
+    color: var(--white);
     padding: 5px 15px;
     border-radius: 100px;
     opacity: 100%;

--- a/style/modules/emailForm.css
+++ b/style/modules/emailForm.css
@@ -7,7 +7,7 @@
 
 .emailForm--title {
     font-size: 20px;
-    color: #303030;
+    color: var(--dark-gray);
 }
 
 .emailForm--inputBox {

--- a/style/modules/emailForm.css
+++ b/style/modules/emailForm.css
@@ -33,13 +33,13 @@
 
 .emailForm--inputBox:focus,
 textarea:focus {
-    box-shadow: 0 0 5px rgba(81, 203, 238, 1);
-    border-color: rgba(81, 203, 238, 1);
+    box-shadow: 0 0 5px var(--focus-ring-good);
+    border-color: var(--focus-ring-good);
 }
 
 .emailForm--inputBox:invalid:focus:not(:placeholder-shown) {
-    box-shadow: 0 0 5px rgba(228, 72, 72, 0.5);
-    border-color: rgba(228, 72, 72, 0.5);
+    box-shadow: 0 0 5px var(--focus-ring-bad);
+    border-color: var(--focus-ring-bad);
 }
 
 @media only screen and (max-width: 600px) {

--- a/style/modules/emailForm.css
+++ b/style/modules/emailForm.css
@@ -28,7 +28,7 @@
 
 .emailForm--inputBox::placeholder {
     font-style: italic;
-    color: gray;
+    color: var(--gray);
 }
 
 .emailForm--inputBox:focus,

--- a/style/modules/event.css
+++ b/style/modules/event.css
@@ -19,7 +19,7 @@
 .event--text {
     font-size: 17px;
     padding: 0 40px;
-    color: #303030;
+    color: var(--dark-gray);
 }
 
 .event--bottom {

--- a/style/modules/event.css
+++ b/style/modules/event.css
@@ -11,7 +11,7 @@
 
 .event--title {
     padding: 0 40px;
-    color: #113255;
+    color: --var(dark-blue);
     font-family: "Libre Franklin", sans-serif;
     font-size: 25px;
 }
@@ -28,7 +28,7 @@
 }
 
 .event--dateTitle {
-    color: #113255;
+    color: --var(dark-blue);
     font-family: "Libre Franklin", sans-serif;
     font-size: 20px;
     flex-grow: 0.5;

--- a/style/modules/event.css
+++ b/style/modules/event.css
@@ -38,7 +38,7 @@
 .event--date {
     font-size: 15px;
     flex-grow: 2;
-    color: #606060;
+    color: var(--gray);
 }
 
 .event--btn {
@@ -78,7 +78,7 @@
 
     .event--date {
         font-size: 12px;
-        color: #606060;
+        color: var(--gray);
     }
 
     .event--btn {

--- a/style/modules/event.css
+++ b/style/modules/event.css
@@ -11,7 +11,7 @@
 
 .event--title {
     padding: 0 40px;
-    color: --var(dark-blue);
+    color: var(--dark-blue);
     font-family: "Libre Franklin", sans-serif;
     font-size: 25px;
 }
@@ -28,7 +28,7 @@
 }
 
 .event--dateTitle {
-    color: --var(dark-blue);
+    color: var(--dark-blue);
     font-family: "Libre Franklin", sans-serif;
     font-size: 20px;
     flex-grow: 0.5;

--- a/style/modules/faq.css
+++ b/style/modules/faq.css
@@ -6,7 +6,7 @@
 .faq {
     background-color: var(--white);
     border: 2px solid var(--dark-blue);
-    border-color: --var(dark-blue);
+    border-color: var(--dark-blue);
     border-style: solid;
     border-width: 2px 2px 0 2px;
     padding: 0.75em;
@@ -17,7 +17,7 @@
 }
 
 .faq--question {
-    color: --var(dark-blue);
+    color: var(--dark-blue);
     display: block;
     width: 100%;
     cursor: pointer;

--- a/style/modules/faq.css
+++ b/style/modules/faq.css
@@ -5,8 +5,8 @@
 
 .faq {
     background-color: #ffffff;
-    border: 2px solid #113255;
-    border-color: #113255;
+    border: 2px solid var(--dark-blue);
+    border-color: --var(dark-blue);
     border-style: solid;
     border-width: 2px 2px 0 2px;
     padding: 0.75em;
@@ -17,7 +17,7 @@
 }
 
 .faq--question {
-    color: #113255;
+    color: --var(dark-blue);
     display: block;
     width: 100%;
     cursor: pointer;

--- a/style/modules/faq.css
+++ b/style/modules/faq.css
@@ -4,7 +4,7 @@
 }
 
 .faq {
-    background-color: #ffffff;
+    background-color: var(--white);
     border: 2px solid var(--dark-blue);
     border-color: --var(dark-blue);
     border-style: solid;

--- a/style/modules/infoCard.css
+++ b/style/modules/infoCard.css
@@ -13,7 +13,7 @@
 }
 
 .infoCard--title {
-    color: --var(dark-blue);
+    color: var(--dark-blue);
     font-family: "Libre Franklin", sans-serif;
     font-size: 40px;
     margin: 0;

--- a/style/modules/infoCard.css
+++ b/style/modules/infoCard.css
@@ -13,7 +13,7 @@
 }
 
 .infoCard--title {
-    color: #113255;
+    color: --var(dark-blue);
     font-family: "Libre Franklin", sans-serif;
     font-size: 40px;
     margin: 0;

--- a/style/modules/missionStatement.css
+++ b/style/modules/missionStatement.css
@@ -17,7 +17,7 @@
     position: absolute;
     padding: 20px;
     width: 200px;
-    background-color: white;
+    background-color: var(--white);
     left: 50%;
     transform: translate(-50%, -50%);
 }

--- a/style/modules/missionStatement.css
+++ b/style/modules/missionStatement.css
@@ -3,7 +3,7 @@
     max-width: 60%;
     margin: 0 auto;
     margin-top: 110px;
-    background: white;
+    background: var(--white);
     border: 2px solid var(--dark-blue);
     border-radius: 34px;
     padding: 10px;

--- a/style/modules/missionStatement.css
+++ b/style/modules/missionStatement.css
@@ -26,7 +26,7 @@
     margin-top: 90px;
     font-size: 30px;
     font-style: italic;
-    color: --var(dark-blue);
+    color: var(--dark-blue);
     line-height: 150%;
 }
 

--- a/style/modules/missionStatement.css
+++ b/style/modules/missionStatement.css
@@ -4,7 +4,7 @@
     margin: 0 auto;
     margin-top: 110px;
     background: white;
-    border: 2px solid #113255;
+    border: 2px solid var(--dark-blue);
     border-radius: 34px;
     padding: 10px;
     padding-left: 80px;
@@ -26,7 +26,7 @@
     margin-top: 90px;
     font-size: 30px;
     font-style: italic;
-    color: #113255;
+    color: --var(dark-blue);
     line-height: 150%;
 }
 

--- a/style/modules/muralThumbnail.css
+++ b/style/modules/muralThumbnail.css
@@ -1,7 +1,6 @@
 .muralThumbnail {
     display: block;
     overflow: hidden;
-    background: #f5f5f5;
     transition: opacity 0.5s ease;
 }
 

--- a/style/modules/muralThumbnail.css
+++ b/style/modules/muralThumbnail.css
@@ -10,7 +10,7 @@
 
 .muralThumbnail--location {
     font-size: 13px;
-    color: gray;
+    color: var(--gray);
     padding: 8px 8px 0 15px;
 }
 

--- a/style/modules/navModal.css
+++ b/style/modules/navModal.css
@@ -22,7 +22,7 @@
         text-decoration: none;
         line-height: 200%;
         font-size: 30px;
-        color: #303030;
+        color: var(--dark-gray);
         font-weight: bold;
     }
 

--- a/style/modules/pageHeader.css
+++ b/style/modules/pageHeader.css
@@ -20,7 +20,7 @@
 }
 
 .pageHeader--text {
-    color: #7c7c7c;
+    color: var(--gray);
     font-size: 28px;
     margin-top: 30px;
     margin-bottom: 0;

--- a/style/modules/press.css
+++ b/style/modules/press.css
@@ -4,7 +4,7 @@
     background: #f5f5f5;
     width: 100%;
     max-width: 1600px;
-    color: #606060;
+    color: var(--gray);
     transition: opacity 0.3s, transform 0.3s;
 }
 
@@ -28,7 +28,7 @@
 
 .press--headline {
     font-size: 22px;
-    color: #303030;
+    color: var(--dark-gray);
 }
 
 .press--date {

--- a/style/modules/program.css
+++ b/style/modules/program.css
@@ -15,7 +15,7 @@
 }
 
 .program--title {
-    color: #113255;
+    color: --var(dark-blue);
     font-family: "Libre Franklin", sans-serif;
     font-size: 30px;
 }

--- a/style/modules/program.css
+++ b/style/modules/program.css
@@ -15,7 +15,7 @@
 }
 
 .program--title {
-    color: --var(dark-blue);
+    color: var(--dark-blue);
     font-family: "Libre Franklin", sans-serif;
     font-size: 30px;
 }

--- a/style/modules/program.css
+++ b/style/modules/program.css
@@ -21,7 +21,7 @@
 }
 
 .program--text {
-    color: #303030;
+    color: var(--dark-gray);
     align-self: flex-start;
     line-height: 125%;
 }

--- a/style/modules/program.css
+++ b/style/modules/program.css
@@ -27,7 +27,7 @@
 }
 
 .program--details {
-    color: #606060;
+    color: var(--gray);
     margin-bottom: 0;
 }
 

--- a/style/modules/sectionHeading.css
+++ b/style/modules/sectionHeading.css
@@ -1,6 +1,6 @@
 .sectionHeading {
     font-family: "Libre Franklin", sans-serif;
     font-weight: 700;
-    color: --var(dark-blue);
+    color: var(--dark-blue);
     font-size: 48px;
 }

--- a/style/modules/sectionHeading.css
+++ b/style/modules/sectionHeading.css
@@ -1,6 +1,6 @@
 .sectionHeading {
     font-family: "Libre Franklin", sans-serif;
     font-weight: 700;
-    color: #113255;
+    color: --var(dark-blue);
     font-size: 48px;
 }

--- a/style/modules/subFooter.css
+++ b/style/modules/subFooter.css
@@ -20,7 +20,7 @@
 .subFooter--copyright {
     text-align: right;
     flex-grow: 2;
-    color: #DDDDDD;
+    color: var(--silver);
     white-space: nowrap;
     margin: 0;
 }

--- a/style/modules/subFooter.css
+++ b/style/modules/subFooter.css
@@ -2,7 +2,7 @@
     display: flex;
     align-items: center;
     padding: 10px;
-    background-color: #303030;
+    background-color: var(--dark-gray);
 }
 
 .subFooter > *:not(:last-child) {

--- a/style/modules/teamMember.css
+++ b/style/modules/teamMember.css
@@ -1,5 +1,5 @@
 .teamMember {
-    background-color: white;
+    background-color: var(--white);
     text-align: center;
 }
 

--- a/style/modules/teamMember.css
+++ b/style/modules/teamMember.css
@@ -12,7 +12,7 @@
 .teamMember--role {
     padding-bottom: 6px;
     font-size: 15px;
-    color: #606060;
+    color: var(--gray);
 }
 
 .teamMember--photo {
@@ -44,7 +44,7 @@
     .teamMember--role {
         padding-bottom: 4px;
         font-size: 10px;
-        color: #606060;
+        color: var(--gray);
     }
 
     .teamMember--photo {

--- a/style/modules/teamMember.css
+++ b/style/modules/teamMember.css
@@ -6,7 +6,7 @@
 .teamMember--name {
     padding: 6px;
     font-size: 24px;
-    color: #303030;
+    color: var(--dark-gray);
 }
 
 .teamMember--role {
@@ -38,7 +38,7 @@
     .teamMember--name {
         padding: 4px;
         font-size: 17px;
-        color: #303030;
+        color: var(--dark-gray);
     }
 
     .teamMember--role {

--- a/style/modules/testimonial.css
+++ b/style/modules/testimonial.css
@@ -2,7 +2,7 @@
     position: relative;
     margin-top: 100px;
     max-width: 610px;
-    background: white;
+    background: var(--white);
     border: 0.5px solid black;
 }
 

--- a/style/variables.css
+++ b/style/variables.css
@@ -1,6 +1,7 @@
 :root {
     --white: #ffffff;
     --light-gray: #f5f5f5;
+    --silver: #dddddd;
     --gray: #707070;
     --dark-gray: #303030;
     --light-blue: #508eff;

--- a/style/variables.css
+++ b/style/variables.css
@@ -1,12 +1,10 @@
 :root {
-  --white: #ffffff;
-
-  --light-gray: #f5f5f5;
-  --gray: #707070;
-  --dark-gray: #303030;
-
-  --light-blue: #508eff;
-  --dark-blue: #113255;
-  --yellow: #f7e85d;
-  --red: #ff3d3d;
+    --white: #ffffff;
+    --light-gray: #f5f5f5;
+    --gray: #707070;
+    --dark-gray: #303030;
+    --light-blue: #508eff;
+    --dark-blue: #113255;
+    --yellow: #f7e85d;
+    --red: #ff3d3d;
 }

--- a/style/variables.css
+++ b/style/variables.css
@@ -7,4 +7,6 @@
     --dark-blue: #113255;
     --yellow: #f7e85d;
     --red: #ff3d3d;
+    --focus-ring-good: rgba(81, 203, 238, 1);
+    --focus-ring-bad: rgba(228, 72, 72, 0.5);
 }

--- a/style/variables.css
+++ b/style/variables.css
@@ -1,0 +1,12 @@
+:root {
+  --white: #ffffff;
+
+  --light-gray: #f5f5f5;
+  --gray: #707070;
+  --dark-gray: #303030;
+
+  --light-blue: #508eff;
+  --dark-blue: #113255;
+  --yellow: #f7e85d;
+  --red: #ff3d3d;
+}


### PR DESCRIPTION
This is an example of how to use [CSS custom properties (aka CSS variables)](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties).

The variables are a [`variables.css`](https://github.com/MissionBit/BAMPWebsite/pull/40/files#diff-e18dd3866c98ef2f68723611ca3a0424dbca0537b508277c7fb4f375ff608c57) file that's imported by `index.css`, and they're applied to the [`:root` pseudoclass](https://developer.mozilla.org/en-US/docs/Web/CSS/:root) in order to be available everywhere. (FYI the set of places a variable can be used is called its *scope*.)

They are used like e.g. `color: var(--dark-blue);`.

**Note: we're currently using a few different values for "medium gray" -- this PR will make them all `#707070`.**

To do:

- decide on color variables for `emailForm`
- clean up any stragglers