### PR TITLE
Fix appearance of highlighted text in .missionStatement

### DIFF
--- a/style/modules/missionStatement.css
+++ b/style/modules/missionStatement.css
@@ -15,7 +15,7 @@
 
 .missionStatement--logo {
     position: absolute;
-    padding: 20px;
+    padding: 0 20px;
     width: 200px;
     background-color: var(--white);
     left: 50%;

--- a/style/modules/missionStatement.css
+++ b/style/modules/missionStatement.css
@@ -1,15 +1,11 @@
 .missionStatement {
     position: relative;
     max-width: 60%;
-    margin: 0 auto;
-    margin-top: 110px;
+    margin: 72px auto 0;
     background: var(--white);
     border: 2px solid var(--dark-blue);
     border-radius: 34px;
-    padding: 10px;
-    padding-left: 80px;
-    padding-right: 80px;
-    padding-bottom: 40px;
+    padding: 10px 80px 40px;
     text-align: justify;
 }
 
@@ -23,7 +19,7 @@
 }
 
 .missionStatement > p {
-    margin-top: 90px;
+    margin-top: 100px;
     font-size: 30px;
     font-style: italic;
     color: var(--dark-blue);
@@ -32,22 +28,19 @@
 
 @media only screen and (max-width: 600px) {
     .missionStatement {
-        margin-top: 60px;
         max-width: 80%;
-        padding-left: 30px;
-        padding-right: 30px;
-        padding-bottom: 20px;
+        padding: 10px 30px 20px;
         text-align: center;
     }
 
     .missionStatement > p {
         font-size: 16px;
-        margin-top: 60px;
+        margin-top: 45px;
     }
 
     .missionStatement--logo {
         width: 130px;
-        transform: translateY(-85px);
+        transform: translateY(-70px);
         left: 50%;
         margin-left: -80px;
     }


### PR DESCRIPTION
The text highlight box is slightly covered by the logo container. This PR removes the top and bottom padding from that element.

before:
<img width="831" alt="before" src="https://user-images.githubusercontent.com/733916/97650651-7128c780-1a17-11eb-871c-7ec9bfec9d62.png">

after:
<img width="823" alt="Screen Shot 2020-10-29 at 8 23 23 PM" src="https://user-images.githubusercontent.com/733916/97656397-9ec83d80-1a24-11eb-86e5-0af6f5161a71.png">

**Edit: this PR now also tweaks some other padding & margin values, in a few ways:**

1. right now, the top of the logo sits above the margin box for the module, so it could cut into whatever's above it. this PR expands the margin box a bit.
2. right now the logo is a little high in the mobile version, this PR nudges it closer to vertical center
3. collects `margin-top, margin-left`, etc. into `margin` shorthands (same for padding)

This is the before shot for 1: (orange area is the margin of `missionStatement`, so the logo shouldn't go above that): 
<img width="531" alt="Screen Shot 2020-10-29 at 9 51 05 PM" src="https://user-images.githubusercontent.com/733916/97661955-fd94b380-1a32-11eb-8cfa-454881f0fbca.png">

It also adjusts things