### PR TITLE
Sort storybook items dynamically

### DIFF
--- a/storybook/index.html
+++ b/storybook/index.html
@@ -2,14 +2,15 @@
 <html>
     <head>
         <meta charset="utf-8">
-        <script src="script.js" defer></script>
-        <link rel="stylesheet" href="../style/index.css">
-        <link rel="stylesheet" href="style.css">
+        <link rel="stylesheet" href="/style/index.css">
+        <link rel="stylesheet" href="/storybook/style.css">
         <script
             src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
             integrity="sha256-4+XzXVhsDmqanXGHaHvgh1gMQKX40OUvDEBTu8JcmNs="
             crossorigin="anonymous"></script>
-        <script src="../scripts/index.js" type="module" defer></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/ramda/0.25.0/ramda.min.js"></script>
+        <script src="/scripts/index.js" type="module" defer></script>
+        <script src="/storybook/script.js" defer></script>
     </head>
 
     <body>

--- a/storybook/index.html
+++ b/storybook/index.html
@@ -45,6 +45,7 @@
                 </section>
 
                 <section class="demo" data-module-name="navModal">
+                    <p>To show, set browser to mobile width and click hamburger icon in <span class="sbVariant"><a href="#header">.header</a></span>.
                     <div id="navModal" class="navModal">
                         <button id="closeNavModal" class="navModal--close" aria-label="Close">×</button>
                         <ul class="navModal--linkList">

--- a/storybook/index.html
+++ b/storybook/index.html
@@ -373,18 +373,6 @@
                     </div>
                 </section>
 
-                <section class="demo">
-                    <p>Small</p>
-                    <a class="btnLink btnLink-small" href="https://www.youtube.com/watch?v=dQw4w9WgXcQ">Button</a>
-                    <a class="btnLink btnLink-red btnLink-small">Button</a>
-                    <p>Normal</p>
-                    <a class="btnLink">Button</a>
-                    <a class="btnLink btnLink-red">Button</a>
-                    <p>Large</p>
-                    <a class="btnLink btnLink-large">Button</a>
-                    <a class="btnLink btnLink-red btnLink-large">Button</a>
-                </section>
-
                 <section class="demo" data-module-name="muralThumbnail">
                     <button>
                         <div class="box box-red">

--- a/storybook/index.html
+++ b/storybook/index.html
@@ -13,7 +13,7 @@
         <script src="/storybook/script.js" defer></script>
     </head>
 
-    <body>
+    <body style="display: none;">
         <div class="l-topbar">
             <div class="sbTopbar">
                 <img class="sbTopbar--logo" src="../images/logo-gold-border.svg">

--- a/storybook/index.html
+++ b/storybook/index.html
@@ -13,7 +13,7 @@
         <script src="/storybook/script.js" defer></script>
     </head>
 
-    <body style="display: none;">
+    <body style="display: none;"><!-- unhidden in JS after sorting -->
         <div class="l-topbar">
             <div class="sbTopbar">
                 <img class="sbTopbar--logo" src="../images/logo-gold-border.svg">

--- a/storybook/index.html
+++ b/storybook/index.html
@@ -320,12 +320,11 @@
                 </section>
 
                 <section class="demo" data-module-name="pageHeader">
-                        <div class="pageHeader">
-                            <img class="pageHeader--img" src="https://i.pinimg.com/originals/e8/c7/c4/e8c7c4d4e14a9e3b21faf3d7b37c5b03.jpg">
-                            <div class="box">
-                                <h1 class="sectionHeading">BAMP</h1>
-                                <p class="pageHeader--text">BAMP is a nonprofit organization of local artists dedicated to facilitating and creating public art.  Our vision is to turn bare, blighted walls into artistic gateways into the community's surrounding environment.</p>
-                            </div>
+                    <div class="pageHeader">
+                        <img class="pageHeader--img" src="https://i.pinimg.com/originals/e8/c7/c4/e8c7c4d4e14a9e3b21faf3d7b37c5b03.jpg">
+                        <div class="box">
+                            <h1 class="sectionHeading">BAMP</h1>
+                            <p class="pageHeader--text">BAMP is a nonprofit organization of local artists dedicated to facilitating and creating public art.  Our vision is to turn bare, blighted walls into artistic gateways into the community's surrounding environment.</p>
                         </div>
                     </div>
                 </section>

--- a/storybook/script.js
+++ b/storybook/script.js
@@ -46,8 +46,12 @@ const reinsert = elem => {
     parent.append(elem)
 }
 
-for (const demo of sortBy(moduleName, $('.demo'))) {
-    finishSection(demo)
-    appendNavLink(demo)
+const sortedDemos = sortBy(moduleName, $('.demo'))
+
+for (const demo of sortedDemos) {
     reinsert(demo)
+    appendNavLink(demo)
+    finishSection(demo)
 }
+
+$('body').show()

--- a/storybook/script.js
+++ b/storybook/script.js
@@ -1,3 +1,10 @@
+const { sortBy, pipe, prop } = R
+
+const moduleName = pipe(prop('dataset'), prop('moduleName'))
+
+const bookmark = name =>
+    $('<a>').prop('name', `sb-${name}`)
+
 const heading = text =>
     $('<h1>').addClass('sbHeading').text(text)
 
@@ -14,27 +21,33 @@ const page = contents => {
     return $('<div>').addClass('sbPage').append(titlebar(), inner)
 }
 
-const bookmark = moduleName =>
-    $('<a>').prop('name', moduleName)
+const finishSection = demo => {
+    const children = $(demo).children()
 
-const navItem = moduleName => {
+    $(demo).empty().append([
+        bookmark(moduleName(demo)),
+        heading(moduleName(demo)),
+        page(children)
+    ])
+}
+
+const navLink = name => {
     const item = $('<li>').addClass('sbNavList--item')
-    const link = $('<a>').prop('href', '#' + moduleName).text(moduleName)
+    const link = $('<a>').prop('href', `#sb-${name}`).text(name)
     return item.append(link)
 }
 
+const appendNavLink = demo =>
+    $('ul.sbNavList').append(navLink(moduleName(demo)))
 
-const nav = $('nav ul')
+const reinsert = elem => {
+    const parent = $(elem).parent()
+    $(elem).remove()
+    parent.append(elem)
+}
 
-for (const section of $('.demo')) {
-    const contents = $(section).children()
-    const moduleName = $(section).data('module-name')
-
-    $(section).empty().append([
-        bookmark(moduleName),
-        heading(moduleName),
-        page(contents)
-    ])
-
-    $(nav).append(navItem(moduleName))
+for (const demo of sortBy(moduleName, $('.demo'))) {
+    finishSection(demo)
+    appendNavLink(demo)
+    reinsert(demo)
 }


### PR DESCRIPTION
This PR updates the storybook JS to sort the module demos alphabetically, regardless of HTML order.

It also fixes a few issues with the storybook:

* adds a `sb-` prefix to fragment identifiers (this fixes the sidebar link to `navModal`)
* changes JS & CSS paths to be absolute (the relative paths broke `npm serve` for some reason that I don't want to investigate)
* removes a duplicate, anonymous `.btnLink` demo
* removes an extra closing `</div>` that was making the sidebar less sticky

<img width="1558" alt="Screen Shot 2020-11-03 at 1 25 27 PM" src="https://user-images.githubusercontent.com/733916/98042229-1a850a00-1dd8-11eb-87cd-6fdce4bf0518.png">

#### Notes:

* storybook now requires https://ramdajs.com/ (specifically the `sortBy`, `pipe`, and `prop` functions)