### PR TITLE
Siema with dots [base branch is testimonial-buttons]

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,8 +73,8 @@
                     </div>
                 </div>
             </div>
-            <div class="carousel--slider carousel--prev">&#10094;</div>
-            <div class="carousel--slider carousel--next">&#10095;</div>
+            <button class="carousel--slider carousel--prev">&#10094;</button>
+            <button class="carousel--slider carousel--next">&#10095;</button>
         </section>
 
         <section class="l-section">

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -1,4 +1,5 @@
 import './vendor/siema.min.js'
+import './vendor/siemaWithDots.js'
 import './header.js'
 import './mural.js'
 import './carousel.js'

--- a/scripts/testimonials.js
+++ b/scripts/testimonials.js
@@ -1,31 +1,31 @@
 function setUpCarousel(root) {
     const siema = new SiemaWithDots({
-      selector: root.querySelector('.carousel--items'),
-      duration: 200,
-      easing: 'ease-out',
-      perPage: 1,
-      startIndex: 0,
-      draggable: true,
-      multipleDrag: true,
-      threshold: 20,
-      loop: true,
-      onInit: function() {
-        this.addDots()
-        this.updateDots()
-      },
-      onChange: function() {
-        this.updateDots()
-      },
+        selector: root.querySelector('.carousel--items'),
+        duration: 200,
+        easing: 'ease-out',
+        perPage: 1,
+        startIndex: 0,
+        draggable: true,
+        multipleDrag: true,
+        threshold: 20,
+        loop: true,
+        onInit: function() {
+            this.addDots()
+            this.updateDots()
+        },
+        onChange: function() {
+            this.updateDots()
+        },
     })
 
     const prevBtn = root.querySelector('.carousel--prev')
     if (prevBtn) {
-      prevBtn.addEventListener('click', () => siema.prev())
+        prevBtn.addEventListener('click', () => siema.prev())
     }
 
     const nextBtn = root.querySelector('.carousel--next')
     if (nextBtn) {
-      nextBtn.addEventListener('click', () => siema.next())
+        nextBtn.addEventListener('click', () => siema.next())
     }
 }
 

--- a/scripts/testimonials.js
+++ b/scripts/testimonials.js
@@ -1,62 +1,36 @@
-const mySiema = new Siema({
-  selector: '.carousel--items',
-  duration: 200,
-  easing: 'ease-out',
-  perPage: 1,
-  startIndex: 0,
-  draggable: true,
-  multipleDrag: true,
-  threshold: 20,
-  loop: false,
-  rtl: false,
-  onInit: () => {},
-  onChange: () => {},
-})
+function setUpCarousel(root) {
+    const siema = new SiemaWithDots({
+      selector: root.querySelector('.carousel--items'),
+      duration: 200,
+      easing: 'ease-out',
+      perPage: 1,
+      startIndex: 0,
+      draggable: true,
+      multipleDrag: true,
+      threshold: 20,
+      loop: true,
+      onInit: function() {
+        this.addDots()
+        this.updateDots()
+      },
+      onChange: function() {
+        this.updateDots()
+      },
+    })
 
-document.querySelector('.carousel--prev').addEventListener('click', () => mySiema.prev());
-document.querySelector('.carousel--next').addEventListener('click', () => mySiema.next());
+    const prevBtn = root.querySelector('.carousel--prev')
+    if (prevBtn) {
+      prevBtn.addEventListener('click', () => siema.prev())
+    }
 
-function setupDots(carousel, itemsCount) {
-  if (itemsCount > 8) {
-      return
-  }
-  let dots = document.createElement("DIV")
-  dots.className = "carousel--dots"
-  carousel.appendChild(dots)
-  for (let i = 0; i < itemsCount; i++) {
-      const dot = document.createElement("DIV")
-      dots.appendChild(dot)
-      dot.dataset.indexDot = i
-      dot.addEventListener("click", (event) => {
-        event.target.classList.add("carousel--dot-is-active")
-        mySiema.goTo(i)
-        const dots = document.querySelectorAll(".carousel--dots")
-        for (const dot of dots) {
-          dot.classList.remove("carousel--dot-is-active")
-        }
-      })
-  }
-  return dots
+    const nextBtn = root.querySelector('.carousel--next')
+    if (nextBtn) {
+      nextBtn.addEventListener('click', () => siema.next())
+    }
 }
 
-function updateItems(items, dots) {
-  let index = parseInt(items.dataset.index, 10)
-  items = items.querySelectorAll(".carousel--item")
-  for (let i = 0; i < items.length; i++) {
-      if (i != index) {
-          items[i].classList.add("carousel--item-is-hidden")
-          if (dots) {
-              dots.children[i].classList.remove("carousel--dot-is-active")
-          }
-      } else {
-          items[i].classList.remove("carousel--item-is-hidden")
-          if (dots) {
-              dots.children[i].classList.add("carousel--dot-is-active")
-          }
-      }
-  }
-}
+const carousels = document.querySelectorAll('.carousel')
 
-const carousel = document.querySelector(".carousel")
-const items = carousel.querySelector(".carousel--items")
-let dots = setupDots(carousel, items.querySelectorAll(".carousel--item").length)
+for (const c of carousels) {
+    setUpCarousel(c)
+}

--- a/scripts/vendor/siemaWithDots.js
+++ b/scripts/vendor/siemaWithDots.js
@@ -1,0 +1,45 @@
+// slightly modified version of a codepen by Pawel Grzybek
+// at https://codepen.io/pawelgrzybek/pen/boQQWy
+
+// extend a Siema class by two methods
+// addDots - to create a markup for dots
+// updateDots - to update classes on dots on change callback
+class SiemaWithDots extends Siema {
+  addDots() {
+    // create a contnier for all dots
+    // add a class 'dots' for styling reason
+    this.dots = document.createElement('div');
+    this.dots.classList.add('carousel--dots');
+
+    // loop through slides to create a number of dots
+    for(let i = 0; i < this.innerElements.length; i++) {
+      // create a dot
+      const dot = document.createElement('button');
+
+      // add a class to dot
+      dot.classList.add('carousel--dot');
+
+      // add an event handler to each of them
+      dot.addEventListener('click', () => {
+        this.goTo(i);
+      })
+
+      // append dot to a container for all of them
+      this.dots.appendChild(dot);
+    }
+
+    // add the container full of dots after selector
+    this.selector.parentNode.insertBefore(this.dots, this.selector.nextSibling);
+  }
+
+  updateDots() {
+    // loop through all dots
+    for(let i = 0; i < this.dots.querySelectorAll('button').length; i++) {
+      // if current dot matches currentSlide prop, add a class to it, remove otherwise
+      const addOrRemove = this.currentSlide === i ? 'add' : 'remove';
+      this.dots.querySelectorAll('button')[i].classList[addOrRemove]('carousel--dot-is-active');
+    }
+  }
+}
+
+window.SiemaWithDots = SiemaWithDots

--- a/storybook/index.html
+++ b/storybook/index.html
@@ -33,9 +33,9 @@
                             <img class="carousel--item" src="https://media.istockphoto.com/photos/child-hands-formig-heart-shape-picture-id951945718?k=6&m=951945718&s=612x612&w=0&h=ih-N7RytxrTfhDyvyTQCA5q5xKoJToKSYgdsJ_mHrv0=">
                             <img class="carousel--item" src="https://cdn.eso.org/images/thumb300y/eso1907a.jpg">
                             <video class="carousel--item" controls=""><source src="http://media.w3.org/2010/05/sintel/trailer.mp4"></video>
-                            <div class="carousel--slider carousel--prev">&#10094;</div>
-                            <div class="carousel--slider carousel--next">&#10095;</div>
                         </div>
+                        <button class="carousel--slider carousel--prev">&#10094;</button>
+                        <button class="carousel--slider carousel--next">&#10095;</button>
                     </div>
                 </section>
 

--- a/style/modules/carousel.css
+++ b/style/modules/carousel.css
@@ -38,7 +38,7 @@
     user-select: none;
 }
 
-.carousel--dots > * {
+.carousel--dot {
     display: inline-block;
     cursor: pointer;
     width: 15px;

--- a/style/modules/carousel.css
+++ b/style/modules/carousel.css
@@ -8,14 +8,17 @@
     cursor: pointer;
     text-align: center;
     border-radius: 50%;
-    width: 20px;
     top: 50%;
-    padding: 16px;
     transform: translateY(-50%);
     margin: 0 10px;
     user-select: none;
     transition: 150ms;
     color: var(--white);
+    font-size: 26px;
+    line-height: 50px;
+    width: 50px;
+    height: 50px;
+    outline: none;
 }
 
 .carousel--slider:hover {


### PR DESCRIPTION
Includes some code from the Siema author to generate DOM elements for dots under the carousel, and add event listeners that know about Siema.

Still uses our styling.

This PR also:
* makes everything clickable into a `button` element (so no more clickable divs)
* *slightly* enlarges the fwd/back arrows
* updates the storybook example (all that was needed was to move the arrows outside of the items list)

**Note: the base branch PR for this is `testimonial-buttons`.**