### PR TITLE
Remove superfluous "../" from image URLs

### DIFF
--- a/about_us.html
+++ b/about_us.html
@@ -51,7 +51,7 @@
         <section class="l-section">
             <div class="missionStatement">
                 <div class="missionStatement--logo">
-                    <img src="../images/logo-gold-border.svg">
+                    <img src="images/logo-gold-border.svg">
                 </div>
                 <p>Our program is constantly establishing new standards of excellence in the practice of public and contemporary art creation and exhibition. Our collaborative dialogue processes empower artists and communities to address and organize issues in the community. Community art builds bridges from conceptual connection to a physical understanding. With close attention to our clients desires the results are beautiful murals that inspire and motivate viewers.</p>
             </div>
@@ -261,7 +261,7 @@
             <div class="footer--panel">
                 <div class="footer--bizCard">
                     <div class="footer--mobileBizCard">
-                        <a href="index.html"><img src="../images/logo-gold-border.svg"></a>
+                        <a href="index.html"><img src="images/logo-gold-border.svg"></a>
                         <div class="footer--mobileButton">
                             <a class="btnLink" href="mailto: bampteamad@gmail.com">Contact</a><br><br>
                             <a class="btnLink btnLink-red" href="https://donorbox.org/bay-area-mural-donations">Donate</a>

--- a/artwork.html
+++ b/artwork.html
@@ -206,7 +206,7 @@
             <div class="footer--panel">
                 <div class="footer--bizCard">
                     <div class="footer--mobileBizCard">
-                        <a href="index.html"><img src="../images/logo-gold-border.svg"></a>
+                        <a href="index.html"><img src="images/logo-gold-border.svg"></a>
                         <div class="footer--mobileButton">
                             <a class="btnLink" href="mailto: bampteamad@gmail.com">Contact</a><br><br>
                             <a class="btnLink btnLink-red" href="https://donorbox.org/bay-area-mural-donations">Donate</a>
@@ -245,11 +245,11 @@
         <div class="subFooter">
             <a class="subFooter--socials" href="mailto: bampteamad@gmail.com"><img class="subFooter--svg" src="images/icons/footer/mail.svg"></a>
             <a class="subFooter--socials" href="https://www.instagram.com/bayareamuralpro/"><img class="subFooter--svg" src="images/icons/footer/instagram.svg"></a>
-            <a class="subFooter--socials" href="#"><img class="subFooter--svg" src="../images/icons/footer/twitter.svg"></a>
-            <a class="subFooter--socials" href="#"><img class="subFooter--svg" src="../images/icons/footer/facebook.svg"></a>
-            <a class="subFooter--socials" href="#"><img class="subFooter--svg" src="../images/icons/footer/youtube.svg"></a>
-            <a class="subFooter--socials" href="#"><img class="subFooter--svg" src="../images/icons/footer/linkedin.svg"></a>
-            <a class="subFooter--socials" href="#"><img class="subFooter--svg" src="../images/icons/footer/yelp.svg"></a>
+            <a class="subFooter--socials" href="#"><img class="subFooter--svg" src="images/icons/footer/twitter.svg"></a>
+            <a class="subFooter--socials" href="#"><img class="subFooter--svg" src="images/icons/footer/facebook.svg"></a>
+            <a class="subFooter--socials" href="#"><img class="subFooter--svg" src="images/icons/footer/youtube.svg"></a>
+            <a class="subFooter--socials" href="#"><img class="subFooter--svg" src="images/icons/footer/linkedin.svg"></a>
+            <a class="subFooter--socials" href="#"><img class="subFooter--svg" src="images/icons/footer/yelp.svg"></a>
             <p class="subFooter--copyright">© 2020 BAY AREA MURAL PROGRAM</p>
         </div>
         <section>
@@ -261,15 +261,15 @@
                         <button class="muralModal--close" aria-label="Close">×</button>
                         <p class="muralModal--text"></p>
                         <p>
-                            <img class="muralModal--icon" src="../images/palette.svg">
+                            <img class="muralModal--icon" src="images/palette.svg">
                             <span class="muralModal--bold">Lead Artist</span><span class="muralModal--text">: Rachel</span>
                         </p>
                         <p>
-                            <img class="muralModal--icon" src="../images/map-marker.svg">
+                            <img class="muralModal--icon" src="images/map-marker.svg">
                             <span class="muralModal--bold">Location</span><span class="muralModal--text">: 15th St. Oakland</span>
                         </p>
                         <div class="muralModal--end">
-                            <img class="muralModal--icon" src="../images/calendar.svg">
+                            <img class="muralModal--icon" src="images/calendar.svg">
                             <span class="muralModal--bold">Date</span><span class="muralModal--text">: July, 2020</span>
                         </div>
                     </div>
@@ -283,15 +283,15 @@
                         <button class="muralModal--close" aria-label="Close">×</button>
                         <p class="muralModal--text"></p>
                         <p>
-                            <img class="muralModal--icon" src="../images/palette.svg">
+                            <img class="muralModal--icon" src="images/palette.svg">
                             <span class="muralModal--bold">Lead Artist</span><span class="muralModal--text">: Rachel</span>
                         </p>
                         <p>
-                            <img class="muralModal--icon" src="../images/map-marker.svg">
+                            <img class="muralModal--icon" src="images/map-marker.svg">
                             <span class="muralModal--bold">Location</span><span class="muralModal--text">: African American Art and Culture Complex - 762 Fulton St. SF</span>
                         </p>
                         <div class="muralModal--end">
-                            <img class="muralModal--icon" src="../images/calendar.svg">
+                            <img class="muralModal--icon" src="images/calendar.svg">
                             <span class="muralModal--bold">Date</span><span class="muralModal--text">: July, 2020</span>
                         </div>
                     </div>
@@ -305,15 +305,15 @@
                         <button class="muralModal--close" aria-label="Close">×</button>
                         <p class="muralModal--text"></p>
                         <p>
-                            <img class="muralModal--icon" src="../images/palette.svg">
+                            <img class="muralModal--icon" src="images/palette.svg">
                             <span class="muralModal--bold">Lead Artist</span><span class="muralModal--text">: Tim</span>
                         </p>
                         <p>
-                            <img class="muralModal--icon" src="../images/map-marker.svg">
+                            <img class="muralModal--icon" src="images/map-marker.svg">
                             <span class="muralModal--bold">Location</span><span class="muralModal--text">: Grand Express Market, Oakland</span>
                         </p>
                         <div class="muralModal--end">
-                            <img class="muralModal--icon" src="../images/calendar.svg">
+                            <img class="muralModal--icon" src="images/calendar.svg">
                             <span class="muralModal--bold">Date</span><span class="muralModal--text">: July, 2020</span>
                         </div>
                     </div>
@@ -327,15 +327,15 @@
                         <button class="muralModal--close" aria-label="Close">×</button>
                         <p class="muralModal--text"></p>
                         <p>
-                            <img class="muralModal--icon" src="../images/palette.svg">
+                            <img class="muralModal--icon" src="images/palette.svg">
                             <span class="muralModal--bold">Lead Artist</span><span class="muralModal--text">: Rachel, Pamela</span>
                         </p>
                         <p>
-                            <img class="muralModal--icon" src="../images/map-marker.svg">
+                            <img class="muralModal--icon" src="images/map-marker.svg">
                             <span class="muralModal--bold">Location</span><span class="muralModal--text">: Design, Draw, Build - 2866 Webster St. Oakland</span>
                         </p>
                         <div class="muralModal--end">
-                            <img class="muralModal--icon" src="../images/calendar.svg">
+                            <img class="muralModal--icon" src="images/calendar.svg">
                             <span class="muralModal--bold">Date</span><span class="muralModal--text">: July, 2020</span>
                         </div>
                     </div>
@@ -349,15 +349,15 @@
                         <button class="muralModal--close" aria-label="Close">×</button>
                         <p class="muralModal--text"></p>
                         <p>
-                            <img class="muralModal--icon" src="../images/palette.svg">
+                            <img class="muralModal--icon" src="images/palette.svg">
                             <span class="muralModal--bold">Lead Artist</span><span class="muralModal--text">: Rachel </span>
                         </p>
                         <p>
-                            <img class="muralModal--icon" src="../images/map-marker.svg">
+                            <img class="muralModal--icon" src="images/map-marker.svg">
                             <span class="muralModal--bold">Location</span><span class="muralModal--text">: Lodestar Public School - 701 105th Ave. Oakland</span>
                         </p>
                         <div class="muralModal--end">
-                            <img class="muralModal--icon" src="../images/calendar.svg">
+                            <img class="muralModal--icon" src="images/calendar.svg">
                             <span class="muralModal--bold">Date</span><span class="muralModal--text">: April, 2020</span>
                         </div>
                     </div>
@@ -371,15 +371,15 @@
                         <button class="muralModal--close" aria-label="Close">×</button>
                         <p class="muralModal--text"></p>
                         <p>
-                            <img class="muralModal--icon" src="../images/palette.svg">
+                            <img class="muralModal--icon" src="images/palette.svg">
                             <span class="muralModal--bold">Lead Artist</span><span class="muralModal--text">: Andre</span>
                         </p>
                         <p>
-                            <img class="muralModal--icon" src="../images/map-marker.svg">
+                            <img class="muralModal--icon" src="images/map-marker.svg">
                             <span class="muralModal--bold">Location</span><span class="muralModal--text">: Whole Foods Market 230 Bay Pl Oakland, CA</span>
                         </p>
                         <div class="muralModal--end">
-                            <img class="muralModal--icon" src="../images/calendar.svg">
+                            <img class="muralModal--icon" src="images/calendar.svg">
                             <span class="muralModal--bold">Date</span><span class="muralModal--text">:December, 2018</span>
                         </div>
                     </div>
@@ -393,15 +393,15 @@
                         <button class="muralModal--close" aria-label="Close">×</button>
                         <p class="muralModal--text">Awarded grant.</p>
                         <p>
-                            <img class="muralModal--icon" src="../images/palette.svg">
+                            <img class="muralModal--icon" src="images/palette.svg">
                             <span class="muralModal--bold">Lead Artist</span><span class="muralModal--text">: Andre</span>
                         </p>
                         <p>
-                            <img class="muralModal--icon" src="../images/map-marker.svg">
+                            <img class="muralModal--icon" src="images/map-marker.svg">
                             <span class="muralModal--bold">Location</span><span class="muralModal--text">: 301 Georgia St. Vallejo, CA</span>
                         </p>
                         <div class="muralModal--end">
-                            <img class="muralModal--icon" src="../images/calendar.svg">
+                            <img class="muralModal--icon" src="images/calendar.svg">
                             <span class="muralModal--bold">Date</span><span class="muralModal--text">:December, 2015</span>
                         </div>
                     </div>
@@ -415,15 +415,15 @@
                         <button class="muralModal--close" aria-label="Close">×</button>
                         <p class="muralModal--text"></p>
                         <p>
-                            <img class="muralModal--icon" src="../images/palette.svg">
+                            <img class="muralModal--icon" src="images/palette.svg">
                             <span class="muralModal--bold">Lead Artist</span><span class="muralModal--text">: Rachel </span>
                         </p>
                         <p>
-                            <img class="muralModal--icon" src="../images/map-marker.svg">
+                            <img class="muralModal--icon" src="images/map-marker.svg">
                             <span class="muralModal--bold">Location</span><span class="muralModal--text">: 2148 Broadway Oakland</span>
                         </p>
                         <div class="muralModal--end">
-                            <img class="muralModal--icon" src="../images/calendar.svg">
+                            <img class="muralModal--icon" src="images/calendar.svg">
                             <span class="muralModal--bold">Date</span><span class="muralModal--text">:August, 2020</span>
                         </div>
                     </div>
@@ -437,15 +437,15 @@
                         <button class="muralModal--close" aria-label="Close">×</button>
                         <p class="muralModal--text"></p>
                         <p>
-                            <img class="muralModal--icon" src="../images/palette.svg">
+                            <img class="muralModal--icon" src="images/palette.svg">
                             <span class="muralModal--bold">Lead Artist</span><span class="muralModal--text">: Bobby</span>
                         </p>
                         <p>
-                            <img class="muralModal--icon" src="../images/map-marker.svg">
+                            <img class="muralModal--icon" src="images/map-marker.svg">
                             <span class="muralModal--bold">Location</span><span class="muralModal--text">: Dig Deep Farm - 2700 Fairmont Dr. San Leandro </span>
                         </p>
                         <div class="muralModal--end">
-                            <img class="muralModal--icon" src="../images/calendar.svg">
+                            <img class="muralModal--icon" src="images/calendar.svg">
                             <span class="muralModal--bold">Date</span><span class="muralModal--text">:October, 2019</span>
                         </div>
                     </div>

--- a/events.html
+++ b/events.html
@@ -192,7 +192,7 @@
             <div class="footer--panel">
                 <div class="footer--bizCard">
                     <div class="footer--mobileBizCard">
-                        <a href="index.html"><img src="../images/logo-gold-border.svg"></a>
+                        <a href="index.html"><img src="images/logo-gold-border.svg"></a>
                         <div class="footer--mobileButton">
                             <a class="btnLink" href="mailto: bampteamad@gmail.com">Contact</a><br><br>
                             <a class="btnLink btnLink-red" href="https://donorbox.org/bay-area-mural-donations">Donate</a>

--- a/get_involved.html
+++ b/get_involved.html
@@ -176,7 +176,7 @@
             <div class="footer--panel">
                 <div class="footer--bizCard">
                     <div class="footer--mobileBizCard">
-                        <a href="index.html"><img src="../images/logo-gold-border.svg"></a>
+                        <a href="index.html"><img src="images/logo-gold-border.svg"></a>
                         <div class="footer--mobileButton">
                             <a class="btnLink" href="mailto: bampteamad@gmail.com">Contact</a><br><br>
                             <a class="btnLink btnLink-red" href="https://donorbox.org/bay-area-mural-donations">Donate</a>

--- a/index.html
+++ b/index.html
@@ -44,25 +44,25 @@
             <div class="carousel">
                 <div class="carousel--items">
                     <div class="carousel--item">
-                        <img class="homepageHeader--img" src="../images/index/city-mural.jpeg">
+                        <img class="homepageHeader--img" src="images/index/city-mural.jpeg">
                     </div>
                     <div class="carousel--item">
-                        <img class="homepageHeader--img" src="../images/index/group-photo.jpeg">
+                        <img class="homepageHeader--img" src="images/index/group-photo.jpeg">
                     </div>
                     <div class="carousel--item">
-                        <img class="homepageHeader--img" src="../images/index/mural.jpeg">
+                        <img class="homepageHeader--img" src="images/index/mural.jpeg">
                     </div>
                     <div class="carousel--item">
-                        <img class="homepageHeader--img" src="../images/index/sphpainting.jpeg">
+                        <img class="homepageHeader--img" src="images/index/sphpainting.jpeg">
                     </div>
                     <div class="carousel--item">
-                        <img class="homepageHeader--img" src="../images/index/artists.jpeg">
+                        <img class="homepageHeader--img" src="images/index/artists.jpeg">
                     </div>
                 </div>
                 <button class="carousel--slider carousel--prev">&#10094;</button>
                 <button class="carousel--slider carousel--next">&#10095;</button>
             </section>
-            <img class="homepageHeader--svg" src="../images/speech-bubble.svg">
+            <img class="homepageHeader--svg" src="images/speech-bubble.svg">
         </div>
 
         <section class="l-section">
@@ -74,28 +74,28 @@
             <div class="gridBox gridBox-col4 gridBox-center">
                 <div class="metrics">
                     <div class="metrics--photo">
-                        <img src="../images/index/kapor-center-final.jpeg">
+                        <img src="images/index/kapor-center-final.jpeg">
                     </div>
                     <p class="metrics--stats">100</p>
                     <p class="metrics--text">murals painted</p>
                 </div>
                 <div class="metrics">
                     <div class="metrics--photo">
-                        <img src="../images/index/artists-empowered.jpeg">
+                        <img src="images/index/artists-empowered.jpeg">
                     </div>
                     <p class="metrics--stats">26</p>
                     <p class="metrics--text">artists empowered</p>
                 </div>
                 <div class="metrics">
                     <div class="metrics--photo">
-                        <img src="../images/index/communities.jpeg">
+                        <img src="images/index/communities.jpeg">
                     </div>
                     <p class="metrics--stats">16</p>
                     <p class="metrics--text">communities</p>
                 </div>
                      <div class="metrics">
                     <div class="metrics--photo">
-                        <img src="../images/index/volunteers.jpeg">
+                        <img src="images/index/volunteers.jpeg">
                     </div>
                     <p class="metrics--stats">253</p>
                     <p class="metrics--text">volunteers</p>
@@ -107,7 +107,7 @@
             <h2 class="sectionHeading sectionHeading-centered sectionHeading-spaced">Featured: Plywood Murals</h2>
             <div class="box box-red">
                 <div class="infoCard">
-                    <img class="infoCard--img" src="../images/index/plywood-mural-1.jpeg">
+                    <img class="infoCard--img" src="images/index/plywood-mural-1.jpeg">
                     <div class="infoCard--caption">
                         <p class="infoCard--text">In the wake of George Floyds death, the BAMP and other art organizations have taken to Downtown Oakland, Chinatown to paint plywood boards on storefronts.  The boarded up storefronts serve as great canvases to express the need for social change. BAMP hopes that the social justice artwork can be a way to inform, heal, and remind the community of the ongoing current events.</p>
                         <div class="infoCard--btn">
@@ -296,7 +296,7 @@
             <div class="footer--panel">
                 <div class="footer--bizCard">
                     <div class="footer--mobileBizCard">
-                        <a href="index.html"><img src="../images/logo-gold-border.svg"></a>
+                        <a href="index.html"><img src="images/logo-gold-border.svg"></a>
                         <div class="footer--mobileButton">
                             <a class="btnLink" href="mailto: bampteamad@gmail.com">Contact</a><br><br>
                             <a class="btnLink btnLink-red" href="https://donorbox.org/bay-area-mural-donations">Donate</a>

--- a/programs.html
+++ b/programs.html
@@ -219,7 +219,7 @@
             <div class="footer--panel">
                 <div class="footer--bizCard">
                     <div class="footer--mobileBizCard">
-                        <a href="index.html"><img src="../images/logo-gold-border.svg"></a>
+                        <a href="index.html"><img src="images/logo-gold-border.svg"></a>
                         <div class="footer--mobileButton">
                             <a class="btnLink" href="mailto: bampteamad@gmail.com">Contact</a><br><br>
                             <a class="btnLink btnLink-red" href="https://donorbox.org/bay-area-mural-donations">Donate</a>

--- a/services.html
+++ b/services.html
@@ -88,7 +88,7 @@
             <div class="footer--panel">
                 <div class="footer--bizCard">
                     <div class="footer--mobileBizCard">
-                        <a href="index.html"><img src="../images/logo-gold-border.svg"></a>
+                        <a href="index.html"><img src="images/logo-gold-border.svg"></a>
                         <div class="footer--mobileButton">
                             <a class="btnLink" href="mailto: bampteamad@gmail.com">Contact</a><br><br>
                             <a class="btnLink btnLink-red" href="https://donorbox.org/bay-area-mural-donations">Donate</a>


### PR DESCRIPTION
Many image URLs start with "../" that shouldn't (probably because they need to in the storybook).

These will usually work fine in development, but they break on GitHub pages, because there the site is served from `/BAMPWebsite`.