### PR TITLE
Initially hide extra homepage carousel items

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,16 +46,16 @@
                     <div class="carousel--item">
                         <img class="homepageHeader--img" src="images/index/city-mural.jpeg">
                     </div>
-                    <div class="carousel--item">
+                    <div class="carousel--item carousel--item-is-hidden">
                         <img class="homepageHeader--img" src="images/index/group-photo.jpeg">
                     </div>
-                    <div class="carousel--item">
+                    <div class="carousel--item carousel--item-is-hidden">
                         <img class="homepageHeader--img" src="images/index/mural.jpeg">
                     </div>
-                    <div class="carousel--item">
+                    <div class="carousel--item carousel--item-is-hidden">
                         <img class="homepageHeader--img" src="images/index/sphpainting.jpeg">
                     </div>
-                    <div class="carousel--item">
+                    <div class="carousel--item carousel--item-is-hidden">
                         <img class="homepageHeader--img" src="images/index/artists.jpeg">
                     </div>
                 </div>
@@ -249,7 +249,7 @@
                     <a href="https://www.oaklandca.gov/">
                         <img src="images/supporters/oakland.png">
                     </a>
-                    <a href="http://oakstop.com/">
+                    <a href="https://oakstop.com/">
                         <img src="images/supporters/oakstop.png">
                     </a>
                     <a href="https://www.tpl.org/">

--- a/scripts/carousel.js
+++ b/scripts/carousel.js
@@ -1,3 +1,10 @@
+function unhideItems(root) {
+    const items = root.querySelectorAll('.carousel--item-is-hidden')
+    for (const item of items) {
+        item.classList.remove('carousel--item-is-hidden')
+    }
+}
+
 function setUpCarousel(root) {
     const siema = new SiemaWithDots({
         selector: root.querySelector('.carousel--items'),
@@ -11,6 +18,7 @@ function setUpCarousel(root) {
         onInit: function() {
             this.addDots()
             this.updateDots()
+            unhideItems(root)
         },
         onChange: function() {
             this.updateDots()

--- a/style/modules/carousel.css
+++ b/style/modules/carousel.css
@@ -3,6 +3,21 @@
     width: 100%;
 }
 
+.carousel--items {
+    position: relative;
+}
+
+.carousel--item {
+    display: block;
+    width: 100%;
+    object-fit: cover;
+    transition: 150ms;
+}
+
+.carousel--item-is-hidden {
+    display: none;
+}
+
 .carousel--slider {
     position: absolute;
     cursor: pointer;
@@ -65,22 +80,6 @@
     margin: 15px 3px;
 }
 
-.carousel--items {
-    position: relative;
-}
-
-.carousel--item {
-    display: block;
-    width: 100%;
-    object-fit: cover;
-    transition: 150ms;
-}
-
-.carousel--item-is-hidden {
-    position: fixed;
-    opacity: 0;
-}
-
 .carousel--dots > *:hover {
     background: var(--dark-gray);
 }
@@ -93,7 +92,7 @@
     display: none;
 }
 
-/* next slider gets eaten by the speech bubble on homepage */
+/* hide "next" slider before it can get eaten by the speech bubble */
 @media only screen and (max-width: 800px) {
     .carousel--slider {
         display: none;

--- a/style/modules/homepageHeader.css
+++ b/style/modules/homepageHeader.css
@@ -15,4 +15,5 @@
     top: 30vw;
     right: 0;
     z-index: 5;
+    user-select: none;
 }


### PR DESCRIPTION
We defer loading JS until the page is loaded, but that's not great for the homepage carousel, because you end up being able to see all fo the images on the page before the carousel kicks in.

This attempts to solve it by (manually) hiding every image except the first one, and then having siema unhide them on init.

If this is still wonky I think we could try not deferring execution of (at least some of) the javascript.