### PR TITLE
Tweak text: metrics, copyright notice, events typo

### DIFF
--- a/about_us.html
+++ b/about_us.html
@@ -269,7 +269,7 @@
                         </div>
                     </div>
                     <p>BAY AREA MURAL PROGRAM</p>
-                    <p class="footer--address"><b>Headquarters: </b><br>3463 San Pablo Ave., <br>Oakland, CA 94608  <br>(510) 965-5315</p>
+                    <p class="footer--address"><b>Headquarters: </b><br>3463 San Pablo Ave. <br>Oakland, CA 94608  <br>(510) 965-5315</p>
                     <p>501(c)(3) Non-Profit Organization</p>
                 </div>
             </div>
@@ -306,7 +306,7 @@
             <a class="subFooter--socials" href="#"><img class="subFooter--svg" src="images/icons/footer/youtube.svg"></a>
             <a class="subFooter--socials" href="#"><img class="subFooter--svg" src="images/icons/footer/linkedin.svg"></a>
             <a class="subFooter--socials" href="#"><img class="subFooter--svg" src="images/icons/footer/yelp.svg"></a>
-            <p class="subFooter--copyright">© 2020 BAY AREA MURAL PROGRAM</p>
+            <p class="subFooter--copyright">© 2021 BAY AREA MURAL PROGRAM</p>
         </div>
     </body>
 </html>

--- a/artwork.html
+++ b/artwork.html
@@ -251,7 +251,7 @@
             <a class="subFooter--socials" href="#"><img class="subFooter--svg" src="images/icons/footer/youtube.svg"></a>
             <a class="subFooter--socials" href="#"><img class="subFooter--svg" src="images/icons/footer/linkedin.svg"></a>
             <a class="subFooter--socials" href="#"><img class="subFooter--svg" src="images/icons/footer/yelp.svg"></a>
-            <p class="subFooter--copyright">© 2020 BAY AREA MURAL PROGRAM</p>
+            <p class="subFooter--copyright">© 2021 BAY AREA MURAL PROGRAM</p>
         </div>
         <section>
             <div class="muralModalContainer" data-mural-name="Downtown Oakland">

--- a/events.html
+++ b/events.html
@@ -48,7 +48,7 @@
                 <div class="infoCard">
                     <div class="infoCard--caption">
                         <p class="infoCard--title">Classes</p>
-                        <p class="infoCard--text">Due to concerns over the outbreak of coronavirus (COVID-19) we have decided to postpone out in-person events and classes. Sign up for our email list to stay up to date with BAMP.</p>
+                        <p class="infoCard--text">Due to concerns over the outbreak of coronavirus (COVID-19) we have decided to postpone our in-person events and classes. Sign up for our email list to stay up to date with BAMP.</p>
 
                         <div class="infoCard--btn">
                             <a class="btnLink getUpdates">Get Updates</a>
@@ -206,7 +206,7 @@
                         </div>
                     </div>
                     <p>BAY AREA MURAL PROGRAM</p>
-                    <p class="footer--address"><b>Headquarters: </b><br>3463 San Pablo Ave., <br>Oakland, CA 94608  <br>(510) 965-5315</p>
+                    <p class="footer--address"><b>Headquarters: </b><br>3463 San Pablo Ave. <br>Oakland, CA 94608  <br>(510) 965-5315</p>
                     <p>501(c)(3) Non-Profit Organization</p>
                 </div>
             </div>
@@ -243,7 +243,7 @@
             <a class="subFooter--socials" href="#"><img class="subFooter--svg" src="images/icons/footer/youtube.svg"></a>
             <a class="subFooter--socials" href="#"><img class="subFooter--svg" src="images/icons/footer/linkedin.svg"></a>
             <a class="subFooter--socials" href="#"><img class="subFooter--svg" src="images/icons/footer/yelp.svg"></a>
-            <p class="subFooter--copyright">© 2020 BAY AREA MURAL PROGRAM</p>
+            <p class="subFooter--copyright">© 2021 BAY AREA MURAL PROGRAM</p>
         </div>
     </body>
 </html>

--- a/get_involved.html
+++ b/get_involved.html
@@ -184,7 +184,7 @@
                         </div>
                     </div>
                     <p>BAY AREA MURAL PROGRAM</p>
-                    <p class="footer--address"><b>Headquarters: </b><br>3463 San Pablo Ave., <br>Oakland, CA 94608  <br>(510) 965-5315</p>
+                    <p class="footer--address"><b>Headquarters: </b><br>3463 San Pablo Ave. <br>Oakland, CA 94608  <br>(510) 965-5315</p>
                     <p>501(c)(3) Non-Profit Organization</p>
                 </div>
             </div>
@@ -221,7 +221,7 @@
             <a class="subFooter--socials" href="#"><img class="subFooter--svg" src="images/icons/footer/youtube.svg"></a>
             <a class="subFooter--socials" href="#"><img class="subFooter--svg" src="images/icons/footer/linkedin.svg"></a>
             <a class="subFooter--socials" href="#"><img class="subFooter--svg" src="images/icons/footer/yelp.svg"></a>
-            <p class="subFooter--copyright">© 2020 BAY AREA MURAL PROGRAM</p>
+            <p class="subFooter--copyright">© 2021 BAY AREA MURAL PROGRAM</p>
         </div>
     </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -92,7 +92,7 @@
                         <img src="images/index/communities.jpeg">
                     </div>
                     <p class="metrics--stats">16</p>
-                    <p class="metrics--text">communities</p>
+                    <p class="metrics--text">communities engaged</p>
                 </div>
                      <div class="metrics">
                     <div class="metrics--photo">
@@ -304,7 +304,7 @@
                         </div>
                     </div>
                     <p>BAY AREA MURAL PROGRAM</p>
-                    <p class="footer--address"><b>Headquarters: </b><br>3463 San Pablo Ave., <br>Oakland, CA 94608  <br>(510) 965-5315</p>
+                    <p class="footer--address"><b>Headquarters: </b><br>3463 San Pablo Ave. <br>Oakland, CA 94608  <br>(510) 965-5315</p>
                     <p>501(c)(3) Non-Profit Organization</p>
                 </div>
             </div>
@@ -341,7 +341,7 @@
             <a class="subFooter--socials" href="#"><img class="subFooter--svg" src="images/icons/footer/youtube.svg"></a>
             <a class="subFooter--socials" href="#"><img class="subFooter--svg" src="images/icons/footer/linkedin.svg"></a>
             <a class="subFooter--socials" href="#"><img class="subFooter--svg" src="images/icons/footer/yelp.svg"></a>
-            <p class="subFooter--copyright">© 2020 BAY AREA MURAL PROGRAM</p>
+            <p class="subFooter--copyright">© 2021 BAY AREA MURAL PROGRAM</p>
         </div>
     </body>
 </html>

--- a/programs.html
+++ b/programs.html
@@ -233,7 +233,7 @@
                         </div>
                     </div>
                     <p>BAY AREA MURAL PROGRAM</p>
-                    <p class="footer--address"><b>Headquarters: </b><br>3463 San Pablo Ave., <br>Oakland, CA 94608  <br>(510) 965-5315</p>
+                    <p class="footer--address"><b>Headquarters: </b><br>3463 San Pablo Ave. <br>Oakland, CA 94608  <br>(510) 965-5315</p>
                     <p>501(c)(3) Non-Profit Organization</p>
                 </div>
             </div>
@@ -270,7 +270,7 @@
             <a class="subFooter--socials" href="#"><img class="subFooter--svg" src="images/icons/footer/youtube.svg"></a>
             <a class="subFooter--socials" href="#"><img class="subFooter--svg" src="images/icons/footer/linkedin.svg"></a>
             <a class="subFooter--socials" href="#"><img class="subFooter--svg" src="images/icons/footer/yelp.svg"></a>
-            <p class="subFooter--copyright">© 2020 BAY AREA MURAL PROGRAM</p>
+            <p class="subFooter--copyright">© 2021 BAY AREA MURAL PROGRAM</p>
         </div>
     </body>
 </html>

--- a/services.html
+++ b/services.html
@@ -117,7 +117,7 @@
                         </div>
                     </div>
                     <p>BAY AREA MURAL PROGRAM</p>
-                    <p class="footer--address"><b>Headquarters: </b><br>3463 San Pablo Ave., <br>Oakland, CA 94608  <br>(510) 965-5315</p>
+                    <p class="footer--address"><b>Headquarters: </b><br>3463 San Pablo Ave. <br>Oakland, CA 94608  <br>(510) 965-5315</p>
                     <p>501(c)(3) Non-Profit Organization</p>
                 </div>
             </div>
@@ -154,7 +154,7 @@
             <a class="subFooter--socials" href="#"><img class="subFooter--svg" src="images/icons/footer/youtube.svg"></a>
             <a class="subFooter--socials" href="#"><img class="subFooter--svg" src="images/icons/footer/linkedin.svg"></a>
             <a class="subFooter--socials" href="#"><img class="subFooter--svg" src="images/icons/footer/yelp.svg"></a>
-            <p class="subFooter--copyright">© 2020 BAY AREA MURAL PROGRAM</p>
+            <p class="subFooter--copyright">© 2021 BAY AREA MURAL PROGRAM</p>
         </div>
     </body>
 </html>

--- a/storybook/index.html
+++ b/storybook/index.html
@@ -331,7 +331,7 @@
                         <a class="subFooter--socials" href="#"><img class="subFooter--svg" src="../images/icons/footer/youtube.svg"></a>
                         <a class="subFooter--socials" href="#"><img class="subFooter--svg" src="../images/icons/footer/linkedin.svg"></a>
                         <a class="subFooter--socials" href="#"><img class="subFooter--svg" src="../images/icons/footer/yelp.svg"></a>
-                        <p class="subFooter--copyright">© 2020 BAY AREA MURAL PROGRAM</p>
+                        <p class="subFooter--copyright">© 2021 BAY AREA MURAL PROGRAM</p>
                     </div>
                 </section>
 


### PR DESCRIPTION
### Changes

- Copyright year from 2020 to 2021
- Metrics: added the word "engaged" 
- Fixed the typo on `events.html`
