### PR TITLE
Fix responsiveness of iframes on artwork page

### DIFF
--- a/artwork.html
+++ b/artwork.html
@@ -45,8 +45,8 @@
             <div class="l-section--split">
                 <div class="l-section--splitLeft l-section--splitNarrow">
                     <h1 class="sectionHeading">Artwork</h1>
-                    <p class="u-text--medium">As muralists, we seek to...</p>
-                    <ul class="u-text--medium l-section--list">
+                    <p class="u-text-medium">As muralists, we seek to...</p>
+                    <ul class="u-text-medium u-text-2xHeight">
                         <li>Use art to promote community engagement and development</li>
                         <li>Help communities express themselves and find/explore the power of the visual voice</li>
                         <li>Help share the unique story of each community</li>

--- a/artwork.html
+++ b/artwork.html
@@ -42,8 +42,8 @@
         </div>
 
         <section class="l-section">
-            <div class="l-section--split">
-                <div class="l-section--splitLeft l-section--splitNarrow">
+            <div class="gridBox gridBox-col2 gridBox-col2-collapse">
+                <div>
                     <h1 class="sectionHeading">Artwork</h1>
                     <p class="u-text-medium">As muralists, we seek to...</p>
                     <ul class="u-text-medium u-text-2xHeight">
@@ -53,14 +53,20 @@
                         <li>Develop neighborhood  beautification projects and reclaim public spaces</li>
                         <li>Teach a high quality process of fine-art making in the creation of a community mural</li>
                     </ul>
-                    </div>
-                <div class="l-section--splitRight l-section--splitWide">
-                    <div class="box box-yellow">
-                        <div class="mapBox--img"><iframe src="https://www.google.com/maps/d/embed?mid=1YPg9qBdOFU1nlOm3w-o7S4aSDs1JT_Kw" width="100%" height="480"></iframe>
+                </div>
+                <div class="mapBox box box-yellow">
+                    <div class="mapBox--img">
+                        <div class="fixedRatio">
+                            <iframe
+                                class="fixedRatio--contents"
+                                src="https://www.google.com/maps/d/embed?mid=1YPg9qBdOFU1nlOm3w-o7S4aSDs1JT_Kw"
+                                width="100%"
+                            >
+                            </iframe>
                         </div>
-                        <div class="mapBox--location">BAMP Mural Map</div>
-                        <div class="mapBox--text">The Bay Area Mural Program has painted murals from Vallejo to San Leandro. Look for the closest BAMP Mural on your next commute through the Bay Area.</div>
                     </div>
+                    <div class="mapBox--location">BAMP Mural Map</div>
+                    <div class="mapBox--text">The Bay Area Mural Program has painted murals from Vallejo to San Leandro. Look for the closest BAMP Mural on your next commute through the Bay Area.</div>
                 </div>
             </div>
         </section>
@@ -141,24 +147,28 @@
             </div>
         </section>
         <section class="l-section">
-            <div class="l-section--split">
-                <div class="l-section--splitLeft l-section--splitWide">
-                    <iframe width="100%" height="500" src="https://www.youtube.com/embed/OaKg3WeMKrI" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen>
+            <div class="gridBox gridBox-col2 gridBox-col2-collapse">
+                <div class="fixedRatio fixedRatio-60">
+                    <iframe
+                        class="fixedRatio--contents"
+                        width="100%"
+                        frameborder="0"
+                        src="https://www.youtube.com/embed/OaKg3WeMKrI"
+                        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                        allowfullscreen>
                     </iframe>
                 </div>
-                    <div class="l-section--splitRight l-section--splitNarrow">
-                    <div class="l-section--splitText l-right--text">
-                        <h1 class="sectionHeading sectionHeading-spaced">Want a Mural?</h1>
-                        <p class="u-text-medium u-text--paddingBottom"> Bay Area Mural Program is committed to exceeding your public art needs.
-                        <br>
+                <div class="wantMural">
+                    <h1 class="sectionHeading">Want a Mural?</h1>
+                    <p>
+                        Bay Area Mural Program is committed to exceeding your public art needs.
                         We have designers and muralist that specialize in bringing your ideas to life.
-                        </p><p>
+                    </p>
+                    <p>
                         Questions, comments or special requests?
-                        <br>
                         We’d love to hear from you, so don’t hesitate to reach out today.
-                        </p>
-                        <a class="btnLink">Click Here</a>
-                    </div>
+                    </p>
+                    <a class="btnLink">Click Here</a>
                 </div>
             </div>
         </section>

--- a/programs.html
+++ b/programs.html
@@ -126,7 +126,7 @@
 
         <section class="l-section">
             <h2 class="sectionHeading sectionHeading-sub sectionHeading-centered">Here are some pictures from our classes!</h2>
-            <p class="l-center u-text--medium u-text--paddingBottom">Art has the power to open doors and therefore is an essential component of each
+            <p class="l-center u-text-medium u-padBottom">Art has the power to open doors and therefore is an essential component of each
                 <br class="u-onlyDesktop"> young person’s education The Bay Area Mural Program takes great pride in
                 <br class="u-onlyDesktop"> offering different levels of art and mural training for all ages!
             </p>

--- a/style/index.css
+++ b/style/index.css
@@ -32,3 +32,4 @@
 @import url('modules/metrics.css');
 @import url('modules/fixedRatio.css');
 @import url('modules/calendarBox.css');
+@import url('modules/wantMural.css');

--- a/style/index.css
+++ b/style/index.css
@@ -3,6 +3,7 @@
 @import url('variables.css');
 @import url('base.css');
 @import url('layout.css');
+@import url('utility.css');
 @import url('modules/sectionHeading.css');
 @import url('modules/box.css');
 @import url('modules/gridBox.css');
@@ -31,4 +32,3 @@
 @import url('modules/metrics.css');
 @import url('modules/fixedRatio.css');
 @import url('modules/calendarBox.css');
-@import url('utility.css');

--- a/style/layout.css
+++ b/style/layout.css
@@ -18,27 +18,6 @@
     overflow: hidden;
 }
 
-.l-section--split {
-    display: flex;
-}
-
-.l-section--splitLeft {
-    padding-right: 10%;
-}
-
-.l-section--splitWide {
-    flex-grow: 10;
-}
-
-.l-section--splitNarrow {
-    flex-grow: 1;
-}
-
-.l-section--splitText {
-    text-align: right;
-    line-height: 300%;
-}
-
 @media only screen and (max-width: 600px) {
     .l-section {
         padding: 40px 20px;
@@ -46,23 +25,5 @@
 
     .l-section--text {
         font-size: 18px;
-    }
-
-    .l-section--split {
-        flex-direction: column;
-    }
-
-    .l-section--splitLeft {
-        padding: 0;
-    }
-
-    .l-section--splitText {
-        padding-top: 40px;
-        text-align: center;
-        line-height: 150%;
-    }
-
-    .l-section--splitLeft > iframe {
-        height: 300px;
     }
 }

--- a/style/layout.css
+++ b/style/layout.css
@@ -18,10 +18,6 @@
     overflow: hidden;
 }
 
-.l-section--list {
-    line-height: 200%;
-}
-
 .l-section--split {
     display: flex;
 }
@@ -50,10 +46,6 @@
 
     .l-section--text {
         font-size: 18px;
-    }
-
-    .l-section--list {
-        line-height: 150%;
     }
 
     .l-section--split {

--- a/style/modules/gridBox.css
+++ b/style/modules/gridBox.css
@@ -36,6 +36,7 @@
         flex-basis: 100%;
         margin-bottom: 40px;
     }
+}
 
 @media only screen and (max-width: 600px) {
     .gridBox-col4 > * {

--- a/style/modules/wantMural.css
+++ b/style/modules/wantMural.css
@@ -1,0 +1,10 @@
+.wantMural {
+    font-size: 20px;
+    text-align: right;
+    text-justify: justify;
+}
+
+.wantMural > p {
+    padding-bottom: 20px;
+    line-height: 150%;
+}

--- a/style/utility.css
+++ b/style/utility.css
@@ -6,7 +6,7 @@
     font-size: 20px;
 }
 
-.u-text--paddingBottom {
+.u-padBottom {
     padding-bottom: 30px;
 }
 

--- a/style/utility.css
+++ b/style/utility.css
@@ -2,8 +2,12 @@
     display: none;
 }
 
-.u-text--medium {
+.u-text-medium {
     font-size: 20px;
+}
+
+.u-text-2xHeight {
+    line-height: 200%;
 }
 
 .u-padBottom {
@@ -19,7 +23,11 @@
         display: block;
     }
 
-    .u-text--medium {
+    .u-text-medium {
         font-size: 15px;
+    }
+
+    .u-text-2xHeight {
+        line-height: 150%;
     }
 }


### PR DESCRIPTION
This PR should hopefully deliver Asana task ["the youtube vid gets squished on tablet."](https://app.asana.com/0/1184406596339075/1199953182485464)

![Feb-25-2021 17-38-41](https://user-images.githubusercontent.com/733916/109242648-5893a880-7790-11eb-8f97-3907c52baa3f.gif)

*("want a mural?" behaves similarly but is harder to get a screencap of)*

The idea is to avoid getting into that state by switching to a single-column format sooner. This was the strategy:

* **remove the `.l-section--split...` stuff and use `.gridBox-col2-collapse`, since it mostly does the same thing**
* add a `.wantMural` module for the "want a mural?" section
* use `.fixedRatio` on both iframes

This PR also does some small cleanup of non-module CSS:

* rename `.u-text--medium` to `.u-text-medium` (not a subcomponent of a module)
* rename `.u-text--paddingBottom` to `.u-padBottom` (it's not specific to text)
* replace `.l-section--list` with `.u-text-2xHeight` (it's not page layout and not specific to lists)
* put utility.css above the module imports in `index.css`

The diff is a bit messy. Most individual commits are clean, but the artwork page HTML changes had to be done in one shot.