### PR TITLE
Fix image URLs on programs page

### DIFF
--- a/programs.html
+++ b/programs.html
@@ -70,7 +70,7 @@
                             <p class="program--price">$30.00</p>
                         </div>
                     </div>
-                    <img class="program--img" src="../images/programs/figure-drawing.jpg">
+                    <img class="program--img" src="images/programs/figure-drawing.jpg">
                 </div>
             </div>
             <div class="box box-red">
@@ -89,7 +89,7 @@
                             <p class="program--price">$00.00</p>
                         </div>
                     </div>
-                    <img class="program--img" src="../images/programs/children-painting.jpg">
+                    <img class="program--img" src="images/programs/children-painting.jpg">
                 </div>
             </div>
             <div class="box box-blue">
@@ -108,7 +108,7 @@
                             <p class="program--price">$00.00</p>
                         </div>
                     </div>
-                    <img class="program--img" src="../images/programs/brushes-and-cans.jpg">
+                    <img class="program--img" src="images/programs/brushes-and-cans.jpg">
                 </div>
             </div>
         </section>


### PR DESCRIPTION
This PR delivers the asana task **[images aren't coming up on the programs page](https://app.asana.com/0/1184406596339075/1199953275873925)**.

These image URLs work in development (and likely would work in the real deploy) but are technically incorrect and don't work on github pages, because the GH pages URL starts with a subfolder.