### PR TITLE
Fix width of .muralModal on mobile

### DIFF
--- a/style/modules/muralModal.css
+++ b/style/modules/muralModal.css
@@ -104,6 +104,7 @@
         top: -40px;
         border-top-left-radius: 20px;
         border-top-right-radius: 20px;
+        min-width: unset;
     }
 
     .muralModal--bold {

--- a/style/modules/muralModal.css
+++ b/style/modules/muralModal.css
@@ -13,7 +13,7 @@
     left: 0;
     bottom: 0;
     right: 0;
-    background-color: rgba(0, 0, 0, 0.6);
+    background-color: rgba(0, 0, 0, 0.7);
     z-index: 1000;
     padding: 100px;
     box-sizing: border-box;


### PR DESCRIPTION
This PR delivers **[iphone 6/7/8 - artwork page modal gets cut off](https://app.asana.com/0/1184406596339075/1199953242334612)** by preventing `.muralModal` from being too wide on mobile.

The caption area had a `min-width` set for the desktop layout, but it needed to be unset below the mobile breakpoint.

This PR also slightly darkens the `muralModalContainer` background.

---

before:
![before](https://user-images.githubusercontent.com/733916/110287759-e2ffb780-7f9b-11eb-975a-0bb2f6c20b55.png)

after:
![after](https://user-images.githubusercontent.com/733916/110287764-e5faa800-7f9b-11eb-88d9-f91a67032de7.png)
