### PR TITLE
Fix height of .press in Safari

### DIFF
--- a/style/modules/infoCard.css
+++ b/style/modules/infoCard.css
@@ -9,7 +9,10 @@
 .infoCard--img {
     width: 35%;
     object-fit: cover;
-    height: 30vw;
+
+    /* necessary for safari */
+    min-height: 30vw;
+    height: 100%;
 }
 
 .infoCard--caption {

--- a/style/modules/press.css
+++ b/style/modules/press.css
@@ -20,6 +20,7 @@
 .press--img {
     width: 35%;
     object-fit: cover;
+    height: 30vw;
 }
 
 .press--container {

--- a/style/modules/press.css
+++ b/style/modules/press.css
@@ -20,7 +20,10 @@
 .press--img {
     width: 35%;
     object-fit: cover;
-    height: 100%; /* necessary for safari */
+
+    /* necessary for safari */
+    min-height: 30vw;
+    height: 100%;
 }
 
 .press--container {

--- a/style/modules/press.css
+++ b/style/modules/press.css
@@ -6,6 +6,7 @@
     max-width: 1600px;
     color: var(--gray);
     transition: opacity 0.3s, transform 0.3s;
+    align-items: flex-start; /* safari fix: prevent image from increasing flexbox height */
 }
 
 .press + .press {
@@ -20,7 +21,7 @@
 .press--img {
     width: 35%;
     object-fit: cover;
-    height: 30vw;
+    height: 100%;
 }
 
 .press--container {

--- a/style/modules/press.css
+++ b/style/modules/press.css
@@ -6,7 +6,6 @@
     max-width: 1600px;
     color: var(--gray);
     transition: opacity 0.3s, transform 0.3s;
-    align-items: flex-start; /* safari fix: prevent image from increasing flexbox height */
 }
 
 .press + .press {
@@ -21,7 +20,7 @@
 .press--img {
     width: 35%;
     object-fit: cover;
-    height: 100%;
+    height: 100%; /* necessary for safari */
 }
 
 .press--container {

--- a/style/modules/program.css
+++ b/style/modules/program.css
@@ -1,6 +1,9 @@
 .program {
     display: flex;
     flex-direction: row;
+
+    /* note: align-items must be something other than stretch (the default) for safari,
+     * or else the image needs a fixed height set, or it will force the flexbox to grow taller. */
     align-items: center;
 }
 
@@ -8,7 +11,7 @@
     padding: 15px;
     width: 30%;
     object-fit: cover;
-    height: 25vw;
+    height: 100%;
 }
 
 .program--caption {

--- a/style/modules/program.css
+++ b/style/modules/program.css
@@ -2,8 +2,8 @@
     display: flex;
     flex-direction: row;
 
-    /* note: align-items must be something other than stretch (the default) for safari,
-     * or else the image needs a fixed height set, or it will force the flexbox to grow taller. */
+    /* note: align-items must be something other than stretch (the default) for safari, or
+     * the image needs a fixed height set. otherwise it can force the flexbox to grow taller. */
     align-items: center;
 }
 


### PR DESCRIPTION
This PR delivers **[bug on the press on safari](https://app.asana.com/0/1184406596339075/1200134424988577)**.

The issue (flex modules with images can become too tall on Safari) is the same as in https://github.com/MissionBit/BAMPWebsite/pull/127, which fixed `.infoCard` and `.program`.

The problem occurs [when an image is inside of a flex container which has `align-items` set to the default of `stretch`](https://stackoverflow.com/questions/57516373/image-stretching-in-flexbox-in-safari). Some solutions:

* change  `align-items` to something other than `stretch` (we do this in `.program`)
* set the image height to `100%` or `intrinsic` (again, no stretching)
* set the image height to `100%` and add a `min-height`. this seemed to work best for most things.

I didn't find a solution that allowed the image sizing to be completely "passive" while also stretching to fill the spaces -- like if it were a background image. This would be ideal, but it doesn't seem critical right now. If need be we could probably also add a `max-height` -- this would be most useful on `.press`, but it may never be necessary.

------

before (Safari)
<img width="1217" alt="before" src="https://user-images.githubusercontent.com/733916/113494710-c45be600-949f-11eb-99fe-cab5e6722eb2.png">

after (Safari)
<img width="1227" alt="after" src="https://user-images.githubusercontent.com/733916/113494712-c625a980-949f-11eb-89e0-659ee1bc30fe.png">
