### PR TITLE
Fix Google map placement on Safari

### DIFF
--- a/artwork.html
+++ b/artwork.html
@@ -55,15 +55,12 @@
                     </ul>
                 </div>
                 <div class="mapBox box box-yellow">
-                    <div class="mapBox--img">
-                        <div class="fixedRatio">
-                            <iframe
-                                class="fixedRatio--contents"
-                                src="https://www.google.com/maps/d/embed?mid=1YPg9qBdOFU1nlOm3w-o7S4aSDs1JT_Kw"
-                                width="100%"
-                            >
-                            </iframe>
-                        </div>
+                    <div class="fixedRatio">
+                        <iframe
+                            class="fixedRatio--contents"
+                            src="https://www.google.com/maps/d/embed?mid=1YPg9qBdOFU1nlOm3w-o7S4aSDs1JT_Kw"
+                        >
+                        </iframe>
                     </div>
                     <div class="mapBox--location">BAMP Mural Map</div>
                     <div class="mapBox--text">The Bay Area Mural Program has painted murals from Vallejo to San Leandro. Look for the closest BAMP Mural on your next commute through the Bay Area.</div>

--- a/artwork.html
+++ b/artwork.html
@@ -62,7 +62,7 @@
                         >
                         </iframe>
                     </div>
-                    <div class="mapBox--location">BAMP Mural Map</div>
+                    <div class="mapBox--heading">BAMP Mural Map</div>
                     <div class="mapBox--text">The Bay Area Mural Program has painted murals from Vallejo to San Leandro. Look for the closest BAMP Mural on your next commute through the Bay Area.</div>
                 </div>
             </div>

--- a/artwork.html
+++ b/artwork.html
@@ -55,11 +55,8 @@
                     </ul>
                 </div>
                 <div class="mapBox box box-yellow">
-                    <div class="fixedRatio">
-                        <iframe
-                            class="fixedRatio--contents"
-                            src="https://www.google.com/maps/d/embed?mid=1YPg9qBdOFU1nlOm3w-o7S4aSDs1JT_Kw"
-                        >
+                    <div class="mapBox--map">
+                        <iframe src="https://www.google.com/maps/d/embed?mid=1YPg9qBdOFU1nlOm3w-o7S4aSDs1JT_Kw" width="100%" height="100%">
                         </iframe>
                     </div>
                     <div class="mapBox--heading">BAMP Mural Map</div>

--- a/style/modules/mapBox.css
+++ b/style/modules/mapBox.css
@@ -16,6 +16,10 @@
 }
 
 @media only screen and (max-width: 600px) {
+    .mapBox--map {
+        height: 500px;
+    }
+
     .mapBox--heading {
         font-size: 28px;
     }

--- a/style/modules/mapBox.css
+++ b/style/modules/mapBox.css
@@ -1,3 +1,7 @@
+.mapBox--map {
+    height: 600px;
+}
+
 .mapBox--heading {
     font-family: "Libre Franklin", sans-serif;
     font-weight: 700;
@@ -12,11 +16,7 @@
 }
 
 @media only screen and (max-width: 600px) {
-    .mapBox--img > iframe {
-        height: 60vw;
-    }
-
-    .mapBox--location {
+    .mapBox--heading {
         font-size: 28px;
     }
 

--- a/style/modules/mapBox.css
+++ b/style/modules/mapBox.css
@@ -1,11 +1,3 @@
-.mapBox {
-    display: block;
-}
-
-.mapBox--img {
-    width: 100%;
-}
-
 .mapBox--location {
     font-family: "Libre Franklin", sans-serif;
     font-weight: 700;

--- a/style/modules/mapBox.css
+++ b/style/modules/mapBox.css
@@ -1,4 +1,4 @@
-.mapBox--location {
+.mapBox--heading {
     font-family: "Libre Franklin", sans-serif;
     font-weight: 700;
     color: var(--dark-blue);


### PR DESCRIPTION
Delivers **[safari, mobile - google maps map is off](https://app.asana.com/0/1184406596339075/1200134469141443)**.

The bug also appeared on desktop Safari.

Not really sure what the issue is, but I removed the use of `.fixedRatio` and just set a fixed height for the iframe (600px for desktop, 500px for mobile).

Also:
- renames `.mapBox--location` to `.mapBox--heading`
- renames `.mapBox--img` to `.mapBox--map`
- removes some unnecessary code

-------

before
<img width="1463" alt="before" src="https://user-images.githubusercontent.com/733916/113496268-d6905100-94ac-11eb-97f3-96cef9e91349.png">

after
<img width="1463" alt="after" src="https://user-images.githubusercontent.com/733916/113496269-d7c17e00-94ac-11eb-879d-1fc24b9cb37d.png">

(also tested on my iPhone and it works there)
