### PR TITLE
Adjust nav modal height, allow scrolling, add transition

### DIFF
--- a/about_us.html
+++ b/about_us.html
@@ -8,7 +8,7 @@
         <script src="scripts/index.js" type="module" defer></script>
     </head>
 
-    <body>
+    <body class="u-preload">
         <header class="header">
             <a class="header--linkLogo" href="index.html">
                 <img class="header--logo" src="images/logo-mini-color.svg">

--- a/about_us.html
+++ b/about_us.html
@@ -9,7 +9,7 @@
     </head>
 
     <body>
-        <div class="header">
+        <header class="header">
             <a class="header--linkLogo" href="index.html">
                 <img class="header--logo" src="images/logo-mini-color.svg">
             </a>
@@ -23,7 +23,7 @@
             <button class="header--link header--link-tight"><span class="btnLink btnLink-small getUpdates">Get Updates</span></button>
             <a class="header--link header--link-tight" href="https://donorbox.org/bay-area-mural-donations"><span class="btnLink btnLink-red btnLink-small">Donate</span></a>
             <button id="hamburger" class="header--hamburger">☰</button>
-        </div>
+        </header>
 
         <div id="navModal" class="navModal">
             <button id="closeNavModal" class="navModal--close">×</button>

--- a/artwork.html
+++ b/artwork.html
@@ -8,7 +8,7 @@
         <script src="scripts/index.js" type="module" defer></script>
     </head>
 
-    <body>
+    <body class="u-preload">
         <header class="header">
             <a class="header--linkLogo" href="index.html">
                 <img class="header--logo" src="images/logo-mini-color.svg">

--- a/artwork.html
+++ b/artwork.html
@@ -9,7 +9,7 @@
     </head>
 
     <body>
-        <div class="header">
+        <header class="header">
             <a class="header--linkLogo" href="index.html">
                 <img class="header--logo" src="images/logo-mini-color.svg">
             </a>
@@ -23,7 +23,7 @@
             <button class="header--link header--link-tight"><span class="btnLink btnLink-small getUpdates">Get Updates</span></button>
             <a class="header--link header--link-tight" href="https://donorbox.org/bay-area-mural-donations"><span class="btnLink btnLink-red btnLink-small">Donate</span></a>
             <button id="hamburger" class="header--hamburger">☰</button>
-        </div>
+        </header>
 
         <div id="navModal" class="navModal">
             <button id="closeNavModal" class="navModal--close">×</button>

--- a/events.html
+++ b/events.html
@@ -8,7 +8,7 @@
         <script src="scripts/index.js" type="module" defer></script>
     </head>
 
-    <body>
+    <body class="u-preload">
         <header class="header">
             <a class="header--linkLogo" href="index.html">
                 <img class="header--logo" src="images/logo-mini-color.svg">

--- a/get_involved.html
+++ b/get_involved.html
@@ -8,7 +8,7 @@
         <script src="scripts/index.js" type="module" defer></script>
     </head>
 
-    <body>
+    <body class="u-preload">
         <header class="header">
             <a class="header--linkLogo" href="index.html">
                 <img class="header--logo" src="images/logo-mini-color.svg">

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
         <script src="scripts/index.js" type="module" defer></script>
     </head>
 
-    <body>
+    <body class="u-preload">
         <header class="header">
             <a class="header--linkLogo" href="index.html">
                 <img class="header--logo" src="images/logo-mini-color.svg">

--- a/programs.html
+++ b/programs.html
@@ -8,7 +8,7 @@
         <script src="scripts/index.js" type="module" defer></script>
     </head>
 
-    <body>
+    <body class="u-preload">
         <header class="header">
             <a class="header--linkLogo" href="index.html">
                 <img class="header--logo" src="images/logo-mini-color.svg">

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -9,3 +9,5 @@ import './emailForm.js'
 import './faq.js'
 import './testimonials.js'
 import './carousel.js'
+
+import './preload.js'

--- a/scripts/preload.js
+++ b/scripts/preload.js
@@ -1,0 +1,3 @@
+window.addEventListener("DOMContentLoaded", () => {
+    document.body.classList.remove("u-preload")
+})

--- a/services.html
+++ b/services.html
@@ -8,7 +8,7 @@
         <script src="scripts/index.js" type="module" defer></script>
     </head>
 
-    <body>
+    <body class="u-preload">
         <header class="header">
             <a class="header--linkLogo" href="index.html">
                 <img class="header--logo" src="images/logo-mini-color.svg">

--- a/style/modules/navModal.css
+++ b/style/modules/navModal.css
@@ -1,5 +1,4 @@
 .navModal {
-    display: none;
     padding: 30px;
     background-color: white;
     position: fixed;
@@ -10,10 +9,12 @@
     right: 0;
     z-index: 1000;
     box-sizing: border-box;
+    transform: translateX(-100%);
+    transition: transform 0.2s ease;
 }
 
 .navModal-is-shown {
-    display: block;
+    transform: translateX(0%);
 }
 
 .navModal--linkList {

--- a/style/modules/navModal.css
+++ b/style/modules/navModal.css
@@ -25,7 +25,7 @@
 
 .navModal--link {
     text-decoration: none;
-    line-height: 180%;
+    line-height: 145%;
     font-size: 30px;
     color: var(--dark-gray);
     font-weight: bold;

--- a/style/modules/navModal.css
+++ b/style/modules/navModal.css
@@ -35,11 +35,10 @@
 }
 
 .navModal--close {
+    position: fixed;
     font-size: 60px;
-    float: right;
-    position: relative;
-    right: -20px;
-    top: -30px;
+    right: 12px;
+    top: 0;
 }
 
 .navModal .btnLink {

--- a/style/modules/navModal.css
+++ b/style/modules/navModal.css
@@ -21,6 +21,9 @@
     list-style-type: none;
     padding: 0;
     margin: 0;
+    height: 100%;
+    width: 100%;
+    overflow: auto;
 }
 
 .navModal--link {

--- a/style/modules/navModal.css
+++ b/style/modules/navModal.css
@@ -1,5 +1,5 @@
 .navModal {
-    padding: 30px;
+    padding: 20px 30px;
     background-color: white;
     position: fixed;
     height: 100%;
@@ -38,7 +38,7 @@
     position: fixed;
     font-size: 60px;
     right: 12px;
-    top: 0;
+    top: -2px;
 }
 
 .navModal .btnLink {

--- a/style/utility.css
+++ b/style/utility.css
@@ -1,3 +1,7 @@
+.u-preload * {
+    transition: none !important;
+}
+
 .u-onlyMobile {
     display: none;
 }


### PR DESCRIPTION
This PR delivers **[mobile nav is too tall for some devices but is not scrollable](https://app.asana.com/0/1184406596339075/1199994401073221)**.

Changes:
* the line height for nav modal links is shorter
* the list of links is given a fixed height and `overflow: auto`, so it will scroll if needed
* the `.navModal` hide / show is changed to use a sliding effect
* transitions are prevented on all pages until all DOM content is loaded (using CSS and JS)
  * this avoids a bug where you can see the navModal slide during page load
  
-----

sliding effect transition (the stuff underneath moving is not related, it's just part of the drone video)

<img width="400" src="https://user-images.githubusercontent.com/733916/113497239-ead94b80-94b6-11eb-8573-ded5028f59b9.gif">

height: before

<img width="400" src="https://user-images.githubusercontent.com/733916/113497244-fa589480-94b6-11eb-9e07-a6339634cd1d.PNG">

height: after

<img width="400" src="https://user-images.githubusercontent.com/733916/113497250-02183900-94b7-11eb-98ae-a41f78a01a68.PNG">

