### PR TITLE
Fix programs youtube iframe centering on mobile

### DIFF
--- a/programs.html
+++ b/programs.html
@@ -112,8 +112,9 @@
                 </div>
             </div>
         </section>
-        <section class="l-section">
-            <div class="fixedRatio fixedRatio-60" style="max-width: 1000px; margin-left: auto; margin-right: auto;">
+
+        <section class="l-section l-center">
+            <div class="fixedRatio fixedRatio-60" style="max-width: 1000px;">
                 <iframe
                     class="fixedRatio--contents"
                     src="https://www.youtube.com/embed/BfKU5g2xqd8?controls=0"

--- a/programs.html
+++ b/programs.html
@@ -116,6 +116,7 @@
         <section class="l-section l-center">
             <div class="fixedRatio fixedRatio-60" style="max-width: 1000px;">
                 <iframe
+                    id="programsVideo"
                     class="fixedRatio--contents"
                     src="https://www.youtube.com/embed/BfKU5g2xqd8?controls=0"
                     frameborder="0"

--- a/style/modules/fixedRatio.css
+++ b/style/modules/fixedRatio.css
@@ -21,3 +21,11 @@
     height: 100%;
     object-fit: cover;
 }
+
+/* stupid hack for programs iframe. don't know why it's necessary */
+
+@media only screen and (max-width: 600px) {
+    #programsVideo {
+        width: calc(100vw - 30px) !important;
+    }
+}

--- a/style/modules/fixedRatio.css
+++ b/style/modules/fixedRatio.css
@@ -17,8 +17,6 @@
     position: absolute;
     left: 0;
     top: 0;
-    right: 0;
-    bottom: 0;
     width: 100%;
     height: 100%;
     object-fit: cover;


### PR DESCRIPTION
This PR delivers **[safari, mobile, YT video is off to the left on the programs page](https://app.asana.com/0/1184406596339075/1200134470255027)**. I think.

I can't figure out why this isn't centered on iOS, but it seems like it already should be. The method I used (setting the width exactly so that it would *look* centered) is really dumb and I'm hoping it won't be off-center on other devices, but more testing is needed.

-----------

before
<img width="400px" src="https://user-images.githubusercontent.com/733916/113497817-36422880-94bc-11eb-9936-f563d8cb518e.PNG">

after
<img width="400px" src="https://user-images.githubusercontent.com/733916/113497814-317d7480-94bc-11eb-84d6-4e4f2e2bab85.PNG">