### PR TITLE
Use utility classes for grid-to-carousel hiding

### DIFF
--- a/events.html
+++ b/events.html
@@ -150,7 +150,7 @@
         <section class="l-section">
             <h2 class="sectionHeading sectionHeading-sub sectionHeading-centered">Past events...</h2>
 
-            <div class="gridBox gridBox-col3 gridBox-center gridBox--hidden-on-mobile">
+            <div class="gridBox gridBox-col3 gridBox-center u-onlyDesktop">
                 <div class="fixedRatio fixedRatio-60">
                     <img class="fixedRatio--contents" src="images/events/2BDD79D7-9C8B-4453-933E-5EDB7F600CBD.JPG">
                 </div>
@@ -180,7 +180,7 @@
                 </div>
             </div>
 
-            <section class="carousel carousel--hidden-on-desktop">
+            <section class="carousel u-onlyMobile">
                 <div class="carousel--items">
                     <img class="carousel--item carousel--item-cover" src="images/events/2BDD79D7-9C8B-4453-933E-5EDB7F600CBD.JPG">
                     <img class="carousel--item carousel--item-cover" src="images/events/473EC4D2-AE4E-4305-B343-B10198E8C615.JPG">

--- a/programs.html
+++ b/programs.html
@@ -133,7 +133,7 @@
                 <br class="u-onlyDesktop"> offering different levels of art and mural training for all ages!
             </p>
 
-            <div class="gridBox gridBox-center gridBox-col3 gridBox--hidden-on-mobile">
+            <div class="gridBox gridBox-center gridBox-col3 u-onlyDesktop">
                 <div class="fixedRatio fixedRatio-60">
                     <img class="fixedRatio--contents" src="images/programs/05CAA216-6086-4FFE-ACC3-A652DE4FFE96.JPG">
                 </div>
@@ -163,7 +163,7 @@
                 </div>
             </div>
 
-            <section class="carousel carousel--hidden-on-desktop">
+            <section class="carousel u-onlyMobile">
                 <div class="carousel--items">
                     <img class="carousel--item carousel--item-cover" src="images/programs/05CAA216-6086-4FFE-ACC3-A652DE4FFE96.JPG">
                     <img class="carousel--item carousel--item-cover" src="images/programs/1FEAC200-D3B1-4C28-8E12-EE667988F65A.JPG">

--- a/style/modules/carousel.css
+++ b/style/modules/carousel.css
@@ -93,10 +93,6 @@
     background: var(--dark-gray);
 }
 
-.carousel--hidden-on-desktop {
-    display: none;
-}
-
 /* hide "next" slider before it can get eaten by the speech bubble */
 @media only screen and (max-width: 800px) {
     .carousel--slider {
@@ -110,10 +106,6 @@
 }
 
 @media only screen and (max-width: 600px) {
-    .carousel--hidden-on-desktop {
-        display: block;
-    }
-
     .carousel--item-cover {
         margin-left: auto;
         margin-right: auto;

--- a/style/modules/gridBox.css
+++ b/style/modules/gridBox.css
@@ -42,8 +42,4 @@
     .gridBox-col4 > * {
         flex-basis: 39%;
     }
-
-    .gridBox--hidden-on-mobile {
-        display: none;
-    }
 }

--- a/style/utility.css
+++ b/style/utility.css
@@ -3,7 +3,7 @@
 }
 
 .u-onlyMobile {
-    display: none !important;
+    display: none;
 }
 
 .u-text-medium {
@@ -28,7 +28,7 @@
     }
 
     .u-onlyMobile {
-        display: block !important;
+        display: block;
     }
 
     .u-text-medium {

--- a/style/utility.css
+++ b/style/utility.css
@@ -3,7 +3,7 @@
 }
 
 .u-onlyMobile {
-    display: none;
+    display: none !important;
 }
 
 .u-text-medium {
@@ -24,11 +24,11 @@
 
 @media only screen and (max-width: 600px) {
     .u-onlyDesktop {
-        display: none;
+        display: none !important;
     }
 
     .u-onlyMobile {
-        display: block;
+        display: block !important;
     }
 
     .u-text-medium {


### PR DESCRIPTION
On programs and events we use a carousel below the mobile breakpoint, and a grid of photos above it.

We were using one-off classes for this (`.gridBox--hidden-on-mobile`, `.carousel--hidden-on-desktop`) because we were holding off on using utility classes, but now that we have `.u-onlyMobile` and `.u-onlyDesktop`, it'd be better to use those everywhere.

Just a refactor, no behavioral changes. Extracted from https://github.com/MissionBit/BAMPWebsite/pull/148.