### PR TITLE
Remove infocard+carousel demo from storybook

### DIFF
--- a/storybook/index.html
+++ b/storybook/index.html
@@ -257,29 +257,6 @@
                     </div>
                 </section>
 
-                <section class="demo" data-module-name="infoCard and carousel">
-                    <div class="box box-yellow">
-                        <div class="infoCard">
-                            <div class="carousel">
-                                <div class="carousel--items">
-                                    <div class="carousel--item">
-                                            <img class="infoCardCarousel--img" src="../images/index/plywood-mural-1.jpeg">
-                                    </div>
-                                    <div class="carousel--item">
-                                            <img class="infoCardCarousel--img" src="../images/index/plywood-mural-2.jpeg">
-                                    </div>
-                                    <div class="carousel--slider carousel--prev">&#10094;</div>
-                                    <div class="carousel--slider carousel--next">&#10095;</div>
-                                </div>
-                            </div>
-                            <div class="infoCard--caption">
-                                <p class="infoCard--title">Classes</p>
-                                <p class="infoCard--text">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor</p>
-                            </div>
-                        </div>
-                    </div>
-                </section>
-
                 <section class="demo" data-module-name="missionStatement">
                     <div class="missionStatement">
                         <div class="missionStatement--logo">

--- a/style/modules/infoCard.css
+++ b/style/modules/infoCard.css
@@ -40,12 +40,6 @@
     display: none;
 }
 
-.infoCardCarousel--img {
-    object-fit: cover;
-    width: 100%;
-    height: 30vw;
-}
-
 @media only screen and (max-width: 1100px) {
     .infoCard--img {
         width: 35%;


### PR DESCRIPTION
It's been broken since adding siema. Will restore with something similar if I can get it working again.

Extracted from https://github.com/MissionBit/BAMPWebsite/pull/148.