### PR TITLE
Fix .faq click handler in storybook

### DIFF
--- a/storybook/script.js
+++ b/storybook/script.js
@@ -54,4 +54,10 @@ for (const demo of sortedDemos) {
     finishSection(demo)
 }
 
+/* faq click fix for storybook */
+$('body').delegate('.faq--questionBox', 'click', event => {
+    $(event.target).closest('.faq').toggleClass('faq-is-open')
+    event.preventDefault()
+})
+
 $('body').show()


### PR DESCRIPTION
Following the jQuery refactor, the click event listener for `.faq` questions doesn't work in
the storybook (real pages are fine).

It likely has something to do with the DOM elements being shuffled around for each storybook demo.

The fix uses delegation. Could probably also just not use jQuery for those event handlers,
but it'd be a weird gotcha in the code base that would need commenting. Probably not worth doing
that just for the storybook.

Extracted from https://github.com/MissionBit/BAMPWebsite/pull/148, fixes up https://github.com/MissionBit/BAMPWebsite/pull/150.