### PR TITLE
Stop changing button text size by hiding and showing them

### DIFF
--- a/events.html
+++ b/events.html
@@ -51,11 +51,7 @@
                     <div class="infoCard--caption">
                         <p class="infoCard--title">Classes</p>
                         <p class="infoCard--text">Due to concerns over the outbreak of coronavirus (COVID-19) we have decided to postpone our in-person events and classes. Sign up for our email list to stay up to date with BAMP.</p>
-
-                        <div class="infoCard--btn">
-                            <a class="btnLink getUpdates">Get Updates</a>
-                            <a class="btnLink btnLink-large getUpdates">Get Updates</a>
-                        </div>
+                        <a class="btnLink getUpdates">Get Updates</a>
                     </div>
                 </div>
             </div>

--- a/events.html
+++ b/events.html
@@ -81,12 +81,7 @@
                             <p class="event--dateTitle">Date:</p>
                             <p class="event--date u-onlyDesktop">August 15th, 4 PM</p>
                             <p class="event--date u-onlyMobile">08/15 <br> 4 PM</p>
-                            <div class="event--btn">
-                                <a class="btnLink">Learn More</a>
-                            </div>
-                            <div class="event--btn2">
-                                <a class="btnLink btnLink-small">Learn More</a>
-                            </div>
+                            <a class="btnLink">Learn More</a>
                         </div>
                     </div>
                 </div>
@@ -99,12 +94,7 @@
                             <p class="event--dateTitle">Date:</p>
                             <p class="event--date u-onlyDesktop">August 15th, 4 PM</p>
                             <p class="event--date u-onlyMobile">08/15 <br> 4 PM</p>
-                            <div class="event--btn">
-                                <a class="btnLink">Learn More</a>
-                            </div>
-                            <div class="event--btn2">
-                                <a class="btnLink btnLink-small">Learn More</a>
-                            </div>
+                            <a class="btnLink">Learn More</a>
                         </div>
                     </div>
                 </div>
@@ -117,12 +107,7 @@
                             <p class="event--dateTitle">Date:</p>
                             <p class="event--date u-onlyDesktop">August 15th, 4 PM</p>
                             <p class="event--date u-onlyMobile">08/15 <br> 4 PM</p>
-                            <div class="event--btn">
-                                <a class="btnLink">Learn More</a>
-                            </div>
-                            <div class="event--btn2">
-                                <a class="btnLink btnLink-small">Learn More</a>
-                            </div>
+                            <a class="btnLink">Learn More</a>
                         </div>
                     </div>
                 </div>
@@ -135,12 +120,7 @@
                             <p class="event--dateTitle">Date:</p>
                             <p class="event--date u-onlyDesktop">August 15th, 4 PM</p>
                             <p class="event--date u-onlyMobile">08/15 <br> 4 PM</p>
-                            <div class="event--btn">
-                                <a class="btnLink">Learn More</a>
-                            </div>
-                            <div class="event--btn2">
-                                <a class="btnLink btnLink-small">Learn More</a>
-                            </div>
+                            <a class="btnLink">Learn More</a>
                         </div>
                     </div>
                 </div>

--- a/get_involved.html
+++ b/get_involved.html
@@ -56,10 +56,8 @@
                     <p class="infoCard--title">Art / Mural Class</p>
                     <p class="infoCard--text">BAMP believes it is our duty to inspire the next generation of leaders in our society. <strong>Our Art Classes are on hold due to COVID-19.</strong>
                     </p>
-                    <div class="infoCard--btn1">
-                        <a class="btnLink">Apply</a>
-                    </div>
                     <!-- TODO: make this apply link work -->
+                    <a class="btnLink" href="#">Apply</a>
                 </div>
             </div>
 
@@ -68,10 +66,8 @@
                 <div class="infoCard--caption">
                     <p class="infoCard--title">Volunteer</p>
                     <p class="infoCard--text">Volunteers help us achieve our mission and ignite change throughout the city as we engage in public art and creative programing. Our volunteers serve as ambassadors of the organization with the public through events, paint days, and arts advocacy.</p>
-                    <div class="infoCard--btn1">
-                        <a class="btnLink">Apply</a>
-                    </div>
                     <!-- TODO: make this apply link work -->
+                    <a class="btnLink" href="#">Apply</a>
                 </div>
             </div>
 
@@ -80,9 +76,7 @@
                 <div class="infoCard--caption">
                     <p class="infoCard--title">Donate</p>
                     <p class="infoCard--text">Consider making a donation to support The Bay Area Mural Program in local community projects. You may make a general donation or if you are interested in supporting a specific project or mural in the Bay Area please contact us directly to learn how. All donations are tax-deductible.</p>
-                    <div class="infoCard--btn1">
-                        <a class="btnLink" href="https://donorbox.org/bay-area-mural-donations">Donate</a>
-                    </div>
+                    <a class="btnLink" href="https://donorbox.org/bay-area-mural-donations">Donate</a>
                 </div>
             </div>
 
@@ -91,9 +85,7 @@
                 <div class="infoCard--caption">
                     <p class="infoCard--title">Become a Partner</p>
                     <p class="infoCard--text">You can stay up-to-date and engaged with the B.A.M.P. by sending us an email or checking us out on <a href="https://www.instagram.com/bayareamuralpro/">Instagram</a></p>
-                    <div class="infoCard--btn1">
-                        <a class="btnLink" href="mailto: bampteamad@gmail.com">Contact Us</a>
-                    </div>
+                    <a class="btnLink" href="mailto: bampteamad@gmail.com">Contact Us</a>
                 </div>
             </div>
         </section>

--- a/get_involved.html
+++ b/get_involved.html
@@ -59,6 +59,7 @@
                     <div class="infoCard--btn1">
                         <a class="btnLink">Apply</a>
                     </div>
+                    <!-- TODO: make this apply link work -->
                 </div>
             </div>
 
@@ -70,6 +71,7 @@
                     <div class="infoCard--btn1">
                         <a class="btnLink">Apply</a>
                     </div>
+                    <!-- TODO: make this apply link work -->
                 </div>
             </div>
 

--- a/index.html
+++ b/index.html
@@ -100,10 +100,7 @@
                     <img class="infoCard--img" src="images/index/plywood-mural-1.jpeg">
                     <div class="infoCard--caption">
                         <p class="infoCard--text">In the wake of George Floyds death, the BAMP and other art organizations have taken to Downtown Oakland, Chinatown to paint plywood boards on storefronts.  The boarded up storefronts serve as great canvases to express the need for social change. BAMP hopes that the social justice artwork can be a way to inform, heal, and remind the community of the ongoing current events.</p>
-                        <div class="infoCard--btn">
-                            <a class="btnLink" href="events.html">Events</a>
-                            <a class="btnLink btnLink-large" href="events.html">Events</a>
-                        </div>
+                        <a class="btnLink" href="events.html">Events</a>
                     </div>
                 </div>
             </div>

--- a/programs.html
+++ b/programs.html
@@ -61,12 +61,7 @@
                             Longer Poses  (maybe 30-60 minutes at the end).</p>
                         <p class="program--details">Friday, Feb 28 | 6-9pm | Location</p>
                         <div class="program--bottom">
-                            <div class="program--btn1">
-                                <a class="btnLink">Sign Up</a>
-                            </div>
-                            <div class="program--btn2">
-                                <a class="btnLink btnLink-small">Sign Up</a>
-                            </div>
+                            <a class="btnLink">Sign Up</a>
                             <p class="program--price">$30.00</p>
                         </div>
                     </div>
@@ -80,12 +75,7 @@
                         <p class="program--text">Creative paint class for all age children. This great event has something for everyone in the family as we have programs for children as well as parents. Parents can paint or network with other artistic adults while children paint unique subject matter on canvas and small walls.  We supply the 16″x20″ canvas, easel, paint, brushes, aprons, and step-by-step instructions from experienced artist. No experience necessary! Just bring yourself, positive vibes, have fun, be social and take home a masterpiece.</p>
                         <p class="program--details">Coming Soon</p>
                         <div class="program--bottom">
-                            <div class="program--btn1">
-                                <a class="btnLink">Sign Up</a>
-                            </div>
-                            <div class="program--btn2">
-                                <a class="btnLink btnLink-small">Sign Up</a>
-                            </div>
+                            <a class="btnLink">Sign Up</a>
                             <p class="program--price">$00.00</p>
                         </div>
                     </div>
@@ -99,12 +89,7 @@
                         <p class="program--text">Make space in your calendar to attend an adult painting class. We supply the materials and give you step-by-step instructions from experienced artists. All skill levels welcome, just bring yourself and positive vibes and take home a masterpiece. </p>
                         <p class="program--details">Coming Soon</p>
                         <div class="program--bottom">
-                            <div class="program--btn1">
-                                <a class="btnLink">Sign Up</a>
-                            </div>
-                            <div class="program--btn2">
-                                <a class="btnLink btnLink-small">Sign Up</a>
-                            </div>
+                            <a class="btnLink">Sign Up</a>
                             <p class="program--price">$00.00</p>
                         </div>
                     </div>

--- a/services.html
+++ b/services.html
@@ -64,11 +64,7 @@
                         Learn fundamental techniques and skills for mural painting with BAMP's Lead Artists.
                         <strong>Please note that in-person classes are on hold due to COVID-19.</strong>
                     </p>
-
-                    <div class="infoCard--btn">
-                        <a class="btnLink">Apply</a>
-                        <a class="btnLink btnLink-large">Apply</a>
-                    </div>
+                    <a class="btnLink">Apply</a>
                 </div>
             </div>
             <div class="infoCard box box-yellow">
@@ -80,10 +76,7 @@
                         We have designers and muralist that specialize in bringing your ideas to life.
                         We’d love to hear from you, so don’t hesitate to reach out.
                     </p>
-                    <div class="infoCard--btn">
-                        <a class="btnLink" href="https://forms.gle/u3M88tCXDmf3zUc9A">Mural Form</a>
-                        <a class="btnLink btnLink-large" href="https://forms.gle/u3M88tCXDmf3zUc9A">Mural Form</a>
-                    </div>
+                    <a class="btnLink" href="https://forms.gle/u3M88tCXDmf3zUc9A">Mural Form</a>
                 </div>
             </div>
             <div class="infoCard box box-blue">
@@ -93,10 +86,7 @@
                     <p class="infoCard--text">
                         We now offer screen printing too! To get started on a screen printing consultation with us, click the link below to fill out our short form.
                     </p>
-                    <div class="infoCard--btn">
-                        <a class="btnLink" href="https://forms.gle/gHz7PiYWMstd7ocR9">Printing Form</a>
-                        <a class="btnLink btnLink-large" href="https://forms.gle/gHz7PiYWMstd7ocR9">Printing Form</a>
-                    </div>
+                    <a class="btnLink" href="https://forms.gle/gHz7PiYWMstd7ocR9">Printing Form</a>
                 </div>
             </div>
             <div class="infoCard box box-yellow">
@@ -104,10 +94,7 @@
                 <div class="infoCard--caption">
                     <p class="infoCard--title">Don't see it here?</p>
                     <p class="infoCard--text">Do you have an idea for a unique project that our team of artists and designers can help with? Don't be shy! You can email us below.</p>
-                    <div class="infoCard--btn">
-                        <a class="btnLink">Contact Us</a>
-                        <a class="btnLink btnLink-large">Contact Us</a>
-                    </div>
+                    <a class="btnLink" href-"mailto: bampteamad@gmaill.com">Contact Us</a>
                 </div>
             </div>
         </section>

--- a/storybook/index.html
+++ b/storybook/index.html
@@ -330,12 +330,7 @@
                                 <p class="program--text">Creative paint class for all age children. This great event has something for everyone in the family as we have programs for children as well as parents. Parents can paint or network with other artistic adults while children paint unique subject matter on canvas and small walls.  We supply the 16″x20″ canvas, easel, paint, brushes, aprons, and step-by-step instructions from experienced artist. No experience necessary! Just bring yourself, positive vibes, have fun, be social and take home a masterpiece.</p>
                                 <p class="program--details">Friday, Feb 28 | 6-9pm | Location</p>
                                 <div class="program--bottom">
-                                    <div class="program--btn1">
-                                        <a class="btnLink">Sign Up</a>
-                                    </div>
-                                    <div class="program--btn2">
-                                        <a class="btnLink btnLink-small">Sign Up</a>
-                                    </div>
+                                    <a class="btnLink">Sign Up</a>
                                     <p class="program--price">$00.00</p>
                                 </div>
                             </div>

--- a/storybook/index.html
+++ b/storybook/index.html
@@ -134,12 +134,7 @@
                             <div class="event--bottom">
                                 <p class="event--dateTitle">Date:</p>
                                 <p class="event--date">August 15th, 4 PM</p>
-                                <div class="event--btn">
-                                    <a class="btnLink">Learn More</a>
-                                </div>
-                                <div class="event--btn2">
-                                    <a class="btnLink btnLink-small">Learn More</a>
-                                </div>
+                                <a class="btnLink">Learn More</a>
                             </div>
                         </div>
                         <div class="event box box-blue">
@@ -149,12 +144,7 @@
                             <div class="event--bottom">
                                 <p class="event--dateTitle">Date:</p>
                                 <p class="event--date">August 15th, 4 PM</p>
-                                <div class="event--btn">
-                                    <a class="btnLink">Learn More</a>
-                                </div>
-                                <div class="event--btn2">
-                                    <a class="btnLink btnLink-small">Learn More</a>
-                                </div>
+                                <a class="btnLink">Learn More</a>
                             </div>
                         </div>
                     </div>

--- a/storybook/index.html
+++ b/storybook/index.html
@@ -234,10 +234,7 @@
                             <div class="infoCard--caption">
                                 <p class="infoCard--title">Classes</p>
                                 <p class="infoCard--text">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud...</p>
-                                <div class="infoCard--btn">
-                                    <a class="btnLink">Apply</a>
-                                    <a class="btnLink btnLink-large">Apply</a>
-                                </div>
+                                <a class="btnLink">Apply</a>
                             </div>
                         </div>
                     </div>

--- a/style/modules/event.css
+++ b/style/modules/event.css
@@ -8,17 +8,21 @@
     object-fit: cover;
 }
 
-.event--title {
+.event--title,
+.event--text,
+.event--bottom {
     padding: 0 40px;
+}
+
+.event--title {
     color: var(--dark-blue);
     font-family: "Libre Franklin", sans-serif;
     font-size: 25px;
 }
 
 .event--text {
-    font-size: 17px;
-    padding: 0 40px;
     color: var(--dark-gray);
+    font-size: 17px;
 }
 
 .event--bottom {
@@ -29,24 +33,13 @@
 .event--dateTitle {
     color: var(--dark-blue);
     font-family: "Libre Franklin", sans-serif;
-    font-size: 20px;
     flex-grow: 0.5;
-    padding-left: 40px;
 }
 
 .event--date {
+    color: var(--gray);
     font-size: 15px;
     flex-grow: 2;
-    color: var(--gray);
-}
-
-.event--btn {
-    flex-grow: 0.5;
-    padding-right: 20px;
-}
-
-.event--btn2 {
-    display: none;
 }
 
 @media only screen and (max-width: 600px) {
@@ -60,32 +53,29 @@
         object-fit: cover;
     }
 
+    .event--title,
+    .event--text,
+    .event--bottom {
+        padding: 0 20px;
+    }
+
     .event--title {
-        padding: 0 30px;
         font-size: 16px;
     }
 
     .event--text {
         font-size: 10px;
-        padding: 0 30px;
     }
 
     .event--dateTitle {
         font-size: 14px;
-        padding-left: 30px;
     }
 
     .event--date {
         font-size: 12px;
-        color: var(--gray);
     }
 
-    .event--btn {
-        display: none;
-    }
-
-    .event--btn2 {
-        display: block;
-        padding-right: 20px;
+    .event .btnLink {
+        font-size: 14px;
     }
 }

--- a/style/modules/infoCard.css
+++ b/style/modules/infoCard.css
@@ -40,6 +40,21 @@
     margin-right: auto;
 }
 
+/* ultra-wide desktop */
+@media only screen and (min-width: 1400px) {
+    .infoCard--caption {
+        padding: 20px;
+    }
+
+    .infoCard--text {
+        font-size: 24px;
+    }
+
+    .infoCard .btnLink {
+        font-size: 30px;
+    }
+}
+
 @media only screen and (max-width: 1100px) {
     .infoCard--img {
         width: 35%;
@@ -66,19 +81,5 @@
 
     .infoCard .btnLink {
         margin-left: auto;
-    }
-}
-
-@media only screen and (min-width: 1400px) {
-    .infoCard--caption {
-        padding: 20px;
-    }
-
-    .infoCard--text {
-        font-size: 24px;
-    }
-
-    .infoCard .btnLink {
-        font-size: 30px;
     }
 }

--- a/style/modules/infoCard.css
+++ b/style/modules/infoCard.css
@@ -36,8 +36,8 @@
     padding-bottom: 1.5em;
 }
 
-.infoCard--btn > .btnLink.btnLink-large {
-    display: none;
+.infoCard .btnLink {
+    margin-right: auto;
 }
 
 @media only screen and (max-width: 1100px) {
@@ -64,8 +64,8 @@
         font-size: 15px;
     }
 
-    .infoCard--btn {
-        text-align: center;
+    .infoCard .btnLink {
+        margin-left: auto;
     }
 }
 
@@ -78,12 +78,7 @@
         font-size: 24px;
     }
 
-    .infoCard--btn > .btnLink {
-        display: none;
-    }
-
-    .infoCard--btn > .btnLink.btnLink-large {
-        display: inline-block;
-        margin: 0;
+    .infoCard .btnLink {
+        font-size: 30px;
     }
 }

--- a/style/modules/program.css
+++ b/style/modules/program.css
@@ -80,11 +80,11 @@
     }
 
     .program--text {
-        font-size: 14px;
+        font-size: 16px;
     }
 
     .program--details {
-        font-size: 12px;
+        font-size: 14px;
     }
 
     .program--price {

--- a/style/modules/program.css
+++ b/style/modules/program.css
@@ -43,10 +43,6 @@
     justify-content: space-between;
 }
 
-.program--btn2 {
-    display: none;
-}
-
 .program--price {
     font-size: 30px;
     font-style: italic;
@@ -96,11 +92,7 @@
         font-style: italic;
     }
 
-    .program--btn2 {
-        display: block;
-    }
-
-    .program--btn1 {
-        display: none;
+    .program .btnLink {
+        font-size: 18px;
     }
 }


### PR DESCRIPTION
This PR removes hide/show containers like `<programs--btn1>` in favor of just changing the `btnLink` text size on mobile.

It's good for reducing overrides in the CSS, but it's a little annoying to maintain in the HTML and the fact that we did it 3 or 4 different ways signals to me that it's too involved.

There are also slight tweaks & cleanup for the affected modules (`.event`, `.infoCard`, `.program`). In particular, the way padding is done in `.event` has been simplified.