### PR TITLE
Update order of programs & events photos; remove nudes

### DIFF
--- a/events.html
+++ b/events.html
@@ -121,7 +121,6 @@
 
         <section class="l-section">
             <h2 class="sectionHeading sectionHeading-sub sectionHeading-centered">Past events...</h2>
-
             <div class="gridBox gridBox-col3 gridBox-center u-onlyDesktop">
                 <div class="fixedRatio fixedRatio-60">
                     <img class="fixedRatio--contents" src="images/events/473EC4D2-AE4E-4305-B343-B10198E8C615.JPG">

--- a/events.html
+++ b/events.html
@@ -121,7 +121,7 @@
 
         <section class="l-section">
             <h2 class="sectionHeading sectionHeading-sub sectionHeading-centered">Past events...</h2>
-            <div class="gridBox gridBox-col3 gridBox-center u-onlyDesktop">
+            <div class="gridBox gridBox-col3 gridBox-center u-onlyDesktop js-photoGrid">
                 <div class="fixedRatio fixedRatio-60">
                     <img class="fixedRatio--contents" src="images/events/473EC4D2-AE4E-4305-B343-B10198E8C615.JPG">
                 </div>
@@ -150,18 +150,6 @@
                     <img class="fixedRatio--contents" src="images/events/2BDD79D7-9C8B-4453-933E-5EDB7F600CBD.JPG">
                 </div>
             </div>
-
-            <section class="carousel u-onlyMobile js-carousel-standard">
-                <img class="carousel--item carousel--item-cover" src="images/events/473EC4D2-AE4E-4305-B343-B10198E8C615.JPG">
-                <img class="carousel--item carousel--item-cover" src="images/events/51AB214F-6B94-49DE-A849-1772EDFD7346.JPG">
-                <img class="carousel--item carousel--item-cover" src="images/events/6C00BC14-2041-4464-A6EA-9964E1B8AB47.JPG">
-                <img class="carousel--item carousel--item-cover" src="images/events/7F9772D7-78FF-4255-A933-53B2784D2389.JPG">
-                <img class="carousel--item carousel--item-cover" src="images/events/B0FF38D0-EFEF-413E-BAF5-BF12D02B2D70.JPG">
-                <img class="carousel--item carousel--item-cover" src="images/events/d45a2e_27aca9bed65640f79fc0e916138968a3~mv2.jpg">
-                <img class="carousel--item carousel--item-cover" src="images/events/E4661E71-6AC0-4782-BE2E-ADADFDC997A5.JPG">
-                <img class="carousel--item carousel--item-cover" src="images/events/FAF4A214-4C57-40D5-A6B5-4C71BD66BE8B.JPG">
-                <img class="carousel--item carousel--item-cover" src="images/events/2BDD79D7-9C8B-4453-933E-5EDB7F600CBD.JPG">
-            </section>
         </section>
 
         <div class="footer">

--- a/events.html
+++ b/events.html
@@ -124,9 +124,6 @@
 
             <div class="gridBox gridBox-col3 gridBox-center u-onlyDesktop">
                 <div class="fixedRatio fixedRatio-60">
-                    <img class="fixedRatio--contents" src="images/events/2BDD79D7-9C8B-4453-933E-5EDB7F600CBD.JPG">
-                </div>
-                <div class="fixedRatio fixedRatio-60">
                     <img class="fixedRatio--contents" src="images/events/473EC4D2-AE4E-4305-B343-B10198E8C615.JPG">
                 </div>
                 <div class="fixedRatio fixedRatio-60">
@@ -150,10 +147,12 @@
                 <div class="fixedRatio fixedRatio-60">
                     <img class="fixedRatio--contents" src="images/events/FAF4A214-4C57-40D5-A6B5-4C71BD66BE8B.JPG">
                 </div>
+                <div class="fixedRatio fixedRatio-60">
+                    <img class="fixedRatio--contents" src="images/events/2BDD79D7-9C8B-4453-933E-5EDB7F600CBD.JPG">
+                </div>
             </div>
 
             <section class="carousel u-onlyMobile js-carousel-standard">
-                <img class="carousel--item carousel--item-cover" src="images/events/2BDD79D7-9C8B-4453-933E-5EDB7F600CBD.JPG">
                 <img class="carousel--item carousel--item-cover" src="images/events/473EC4D2-AE4E-4305-B343-B10198E8C615.JPG">
                 <img class="carousel--item carousel--item-cover" src="images/events/51AB214F-6B94-49DE-A849-1772EDFD7346.JPG">
                 <img class="carousel--item carousel--item-cover" src="images/events/6C00BC14-2041-4464-A6EA-9964E1B8AB47.JPG">
@@ -162,6 +161,7 @@
                 <img class="carousel--item carousel--item-cover" src="images/events/d45a2e_27aca9bed65640f79fc0e916138968a3~mv2.jpg">
                 <img class="carousel--item carousel--item-cover" src="images/events/E4661E71-6AC0-4782-BE2E-ADADFDC997A5.JPG">
                 <img class="carousel--item carousel--item-cover" src="images/events/FAF4A214-4C57-40D5-A6B5-4C71BD66BE8B.JPG">
+                <img class="carousel--item carousel--item-cover" src="images/events/2BDD79D7-9C8B-4453-933E-5EDB7F600CBD.JPG">
             </section>
         </section>
 

--- a/programs.html
+++ b/programs.html
@@ -159,31 +159,8 @@
             </section>
         </section>
 
-
         <section class="faqContainer l-section">
             <h2 class="sectionHeading sectionHeading-centered sectionHeading-spaced">Frequently Asked Questions</h2>
-            <!-- <div class="faq">
-                <button class="faq--questionBox">
-                    <div class="faq--question">
-                        What is a virtual art class?
-                    </div>
-                    <div class="faq--plus">+</div>
-                </button>
-                <div class="faq--answer">
-                    N/A
-                </div>
-            </div>
-            <div class="faq">
-                <button class="faq--questionBox">
-                    <div class="faq--question">
-                        How do I log in into my virtual art class?
-                    </div>
-                    <div class="faq--plus">+</div>
-                </button>
-                <div class="faq--answer">
-                    N/A
-                </div>
-            </div> -->
             <div class="faq">
                 <button class="faq--questionBox">
                     <div class="faq--question">

--- a/programs.html
+++ b/programs.html
@@ -120,7 +120,7 @@
                 <br class="u-onlyDesktop"> offering different levels of art and mural training for all ages!
             </p>
 
-            <div class="gridBox gridBox-center gridBox-col3 u-onlyDesktop">
+            <div class="gridBox gridBox-center gridBox-col3 u-onlyDesktop js-photoGrid">
                 <div class="fixedRatio fixedRatio-60">
                     <img class="fixedRatio--contents" src="images/programs/art-class1.jpg">
                 </div>
@@ -146,17 +146,6 @@
                     <img class="fixedRatio--contents" src="images/programs/7F9772D7-78FF-4255-A933-53B2784D2389.JPG">
                 </div>
             </div>
-
-            <section class="carousel u-onlyMobile js-carousel-standard">
-                <img class="carousel--item carousel--item-cover" src="images/programs/art-class1.jpg">
-                <img class="carousel--item carousel--item-cover" src="images/programs/2BDD79D7-9C8B-4453-933E-5EDB7F600CBD.JPG">
-                <img class="carousel--item carousel--item-cover" src="images/programs/4ACADCBD-3E38-4DEE-983C-9A7D66F9E966.JPG">
-                <img class="carousel--item carousel--item-cover" src="images/programs/4DB887FF-71EA-481F-955D-9E4C9322FE2F.JPG">
-                <img class="carousel--item carousel--item-cover" src="images/programs/6C00BC14-2041-4464-A6EA-9964E1B8AB47.JPG">
-                <img class="carousel--item carousel--item-cover" src="images/programs/6CCF2324-A9B7-456E-9DD1-6903567CC075.JPG">
-                <img class="carousel--item carousel--item-cover" src="images/programs/6EAC3A22-DA68-4C67-A5A3-FD2B086FA837.JPG">
-                <img class="carousel--item carousel--item-cover" src="images/programs/7F9772D7-78FF-4255-A933-53B2784D2389.JPG">
-            </section>
         </section>
 
         <section class="faqContainer l-section">

--- a/programs.html
+++ b/programs.html
@@ -122,9 +122,6 @@
 
             <div class="gridBox gridBox-center gridBox-col3 u-onlyDesktop">
                 <div class="fixedRatio fixedRatio-60">
-                    <img class="fixedRatio--contents" src="images/programs/05CAA216-6086-4FFE-ACC3-A652DE4FFE96.JPG">
-                </div>
-                <div class="fixedRatio fixedRatio-60">
                     <img class="fixedRatio--contents" src="images/programs/art-class1.jpg">
                 </div>
                 <div class="fixedRatio fixedRatio-60">
@@ -151,8 +148,7 @@
             </div>
 
             <section class="carousel u-onlyMobile js-carousel-standard">
-                <img class="carousel--item carousel--item-cover" src="images/programs/05CAA216-6086-4FFE-ACC3-A652DE4FFE96.JPG">
-                <img class="carousel--item carousel--item-cover" src="images/programs/1FEAC200-D3B1-4C28-8E12-EE667988F65A.JPG">
+                <img class="carousel--item carousel--item-cover" src="images/programs/art-class1.jpg">
                 <img class="carousel--item carousel--item-cover" src="images/programs/2BDD79D7-9C8B-4453-933E-5EDB7F600CBD.JPG">
                 <img class="carousel--item carousel--item-cover" src="images/programs/4ACADCBD-3E38-4DEE-983C-9A7D66F9E966.JPG">
                 <img class="carousel--item carousel--item-cover" src="images/programs/4DB887FF-71EA-481F-955D-9E4C9322FE2F.JPG">

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -69,3 +69,16 @@ $('#muralGallerySlider').click(event => {
         event.target.innerHTML = "&#10095;"
     }
 })
+
+
+/*
+ * make mobile carousel copies of gridbox (programs & events)
+ */
+$('.js-photoGrid').each((idx, pg) => {
+    const pics = $(pg).find('img').clone().removeClass('fixedRatio--contents').addClass('carousel--item carousel--item-cover')
+    const section = $(pg).parent()
+    const wrapper = $('<div>').addClass('u-onlyMobile')
+    wrapper.append(pics)
+    section.append(wrapper)
+    wrapper.addClass('js-carousel-standard slick-slider slick-dotted')
+})


### PR DESCRIPTION
This PR delivers **[remove nudes (“here are some pictures from our classes”) and fix order](https://app.asana.com/0/1184406596339075/1200178648001394)**.

Had a straggler with the photo of the nude model since there are two copies of everything.

Since this is likely to happen again, I replaced the mobile copies in the HTML with some JS that creates them on the fly.

